### PR TITLE
Reframe P4253 and P4255 around protocol boundaries

### DIFF
--- a/source/2026-09-september/d4253-examining-papers.md
+++ b/source/2026-09-september/d4253-examining-papers.md
@@ -1,7 +1,7 @@
 ---
-title: "Examining Six Observations on std::execution"
+title: "The Hidden Ownership Boundary in std::execution::let_value"
 document: P4253R0
-date: 2026-09-01
+date: 2026-09-07
 intent: info
 audience: SG1, LEWG
 reply-to:
@@ -10,9 +10,9 @@ reply-to:
 
 ## Abstract
 
-One practitioner's published observations about `std::execution` share a common property.
+Default `let_value` can make a valid non-owning result dangle by destroying the predecessor operation state that owns its referent.
 
-Robert Leahy has authored production code in NVIDIA's stdexec<sup>[1]</sup> (the `completion_token`<sup>[2]</sup> and `use_sender`<sup>[3]</sup> adaptors), four WG21 papers (P3373R2<sup>[4]</sup>, P3682R0<sup>[5]</sup>, P3887R1<sup>[6]</sup>, P3950R0<sup>[7]</sup>), and a detailed technical specification of AIO-to-sender bridge invariants<sup>[8]</sup>. This paper examines Leahy's published work and asks what the observations share.
+The adopted P3373R4 transition persists predecessor result datums, destroys the predecessor state, and then invokes the successor factory, permitting storage reuse and earlier resource release. Because a copied `std::span` survives this transition without preserving its referent, and its completion signature cannot distinguish predecessor-owned storage from storage with a surviving external owner, an asynchronous I/O successor that later accesses the bytes violates its buffer-lifetime precondition in the predecessor-owned case. The composition remains safe when the owner survives in persisted arguments, factory state, external state, or an owning result; sender-based I/O generally remains representable.
 
 ---
 
@@ -20,311 +20,401 @@ Robert Leahy has authored production code in NVIDIA's stdexec<sup>[1]</sup> (the
 
 ### R0: September 2026
 
-- Initial revision.
+- Initial version.
 
 ---
 
-## 1. Background
+## Introduction
 
-In broad terms a regular (i.e. synchronous) function call has access to two forms of storage throughout its lifetime (note that the "lifetime" of a regular function call is the time between the call thereto and the return therefrom): stack storage (i.e. "variables with automatic storage duration") and heap storage (i.e. "variables with dynamic storage duration").<sup>[4]</sup>
+`std::execution` provides typed completion channels, static composition of operation states, and structured lifetime management for asynchronous work. P3373R4<sup>[1]</sup> refined one part of that model by allowing `let_value`, `let_error`, and `let_stopped` to reuse predecessor operation-state storage. The adopted rule has a direct consequence when a result object borrows from storage owned by that predecessor.
 
-Leahy establishes in P3373R2<sup>[4]</sup> that asynchronous operations within the framework of `std::execution` analogously have access to two forms of storage throughout their lifetime (note that the "lifetime" of an asynchronous operation is the time between a call to `std::execution::start` on the operation state and the fulfillment of the "receiver contract"): contents of the operation state and heap storage.<sup>[4]</sup> The operation state is the asynchronous analog of a synchronous stack frame - local stable storage the operation can rely upon throughout its lifetime.<sup>[11]</sup> Of course, the analogy is structurally precise: A sender is a fully curried function, a receiver is a call site, connection produces the operation state (i.e. the stack frame), `start` delegates forward progress, and the completion signal is the return.
+The case examined here has four objects with distinct lifetimes: a predecessor operation state, an owner stored within it, a non-owning result datum such as `std::span`, and a successor operation that uses the datum. The concrete witness concerns default `let_value` behavior and a successor that accesses predecessor-owned storage. External owners, owning result types, callable captures, and domain customizations are separate cases.
 
-But despite the structural elegance of the above-described analogues, Leahy identifies one area in which they lack predictive power: the lifetime of the operation state. By the analogy one would expect that the lifetime of the operation state is ended by the invocation of `std::execution::set_value`, `::set_error`, or `::set_stopped`; however this is not guaranteed to be the case in general, and in fact `std::execution` appears to guarantee exactly the opposite.<sup>[4]</sup> Put differently: Whereas the stack pointer for regular synchronous code moves both up and down (i.e. "allocating" and "freeing" stack storage) the analogue thereof for asynchronous code under the framework of `std::execution` moves in only one direction (i.e. such storage is only ever "allocated").<sup>[4]</sup>
+This analysis provides four contributions:
 
-Note that Leahy frames this observation not as an indictment but as an area requiring careful standardization. His P3373R2 proposes ending predecessor operation state lifetimes early for `let_value`, `let_error`, and `let_stopped` - a change which allows the storage occupied thereby to be reused for the operation state of the second operation,<sup>[4]</sup> standardizing existing practice in libunifex. Leahy's P3682R0<sup>[5]</sup> was adopted by plenary vote, removing `std::execution::split`. His P3887R1<sup>[6]</sup> was forwarded by SG1 (8-3-1-0-0) and LEWG (10-5-0-0-0). His production code in NVIDIA's stdexec<sup>[1]</sup> constitutes the most complete AIO-to-sender bridge in the published record - a bridge whose structured concurrency finalization guarantees exactly-once completion under all paths, and whose abandonment detection addresses a problem no prior integration had solved.
+1. A step-by-step account of the P3373R4<sup>[1]</sup> transition as incorporated into the working draft.
+2. A matched pair of predecessors with the same `set_value_t(std::span<std::byte>)` completion signature and different owner placement.
+3. An application of that pair to Boost.Asio's documented asynchronous buffer-lifetime contract.
+4. Safe ownership placements, implementation differences, and unranked design directions.
 
-Which brings us to the question this paper examines: What do Leahy's published observations about `std::execution`, taken together, reveal about the scope of the sender model?
+P3373R4<sup>[1]</sup> supplies the operation-state tradeoff. P1179R1<sup>[2]</sup> supplies established vocabulary for owners and non-owning pointer-like values. P2300R10<sup>[3]</sup> explains the intended `let_value` lifetime of persisted result objects. The current working draft, versioned I/O documentation, and pinned implementation sources supply the remaining evidence.
 
-## 2. The Simplest Integration
+Three assumptions bound the result. The code-equivalent standard wording is the normative baseline. A non-owning descriptor does not extend its referent's lifetime. The asynchronous successor eventually accesses the referenced bytes. No frequency claim about deployed programs follows from the constructed case.
 
-Let us consider the simplest formulation of bridging AIO and `std::execution`. A sender wraps an AIO initiating function. The sender's `connect` produces an operation state containing the initiation and the receiver. The operation state's `start` invokes the initiation with a completion handler that forwards all synthesized values through to the receiver, completing the operation thereby.<sup>[11]</sup>
+## 1. Earlier Predecessor Destruction Provides Reusable Storage
 
-Leahy demonstrates this formulation in his CppCon 2025 talk<sup>[11]</sup>: a sender that wraps an initiating function, a completion handler that sends values down the value channel to the receiver. The code compiles. The operation state opts into the concepts machinery of `std::execution` by providing the needful nested type alias.<sup>[11]</sup> Of course, the sender curries the initiation, and `connect` propagates it into the operation state together with the receiver.
+P3373R4 addresses two child operation states in the `let_*` adaptors: a predecessor and a successor created by a user-supplied factory. The operations do not overlap. Retaining both states until the containing operation ends consumes their combined storage even though only one is active at a time.<sup>[1]</sup>
 
-But then we look at this code further. We notice something curious. Leahy declares `start` as `noexcept`, but the initiation is accepted generically.<sup>[11]</sup> No properties thereof have been established. The implementation can throw an exception and cause `std::terminate` - a consequence which is, as Leahy characterizes it, decidedly unergonomic.<sup>[11]</sup>
+The adopted design persists the predecessor's result datums, ends the predecessor operation-state lifetime, and then constructs the successor. This permits the two child states to share storage. P3373R4 also records a resource-lifetime benefit: An object held in the predecessor state can release a lock or another resource when that suboperation completes instead of when the containing operation is destroyed.<sup>[1]</sup>
 
-And so we are confronted with a question: What does `std::execution` require of `start`?
+The tradeoff is explicit in P3373R4.<sup>[1]</sup> Longer predecessor lifetimes make accesses into predecessor state remain valid, while earlier destruction makes more of those accesses undefined. The selected rule applies the earlier lifetime to `let_value`, `let_error`, and `let_stopped`, where storage reuse provides a concrete reduction. N5047 records application of P3373R4 to the working paper as LWG Poll 10.<sup>[4]</sup>
 
-## 3. Exceptions and the Executor Wrapper
+P3373R4 therefore provides reusable operation-state storage and earlier resource release by ending the predecessor lifetime before the successor is formed.<sup>[1]</sup>
 
-`start` is the point where the synchronous domain transitions to the asynchronous domain. Synchronous reporting mechanisms - such as, for example, throwing an exception - become unavailable.<sup>[11]</sup> It is incumbent upon the implementation of `start` to use only asynchronous reporting mechanisms, such as catching its own exceptions and directing them down the error channel to the receiver.<sup>[11]</sup>
+## 2. `let_value` Destroys the Predecessor Before Calling the Factory
 
-Leahy specifies this requirement precisely in his review of the initial `use_sender` implementation<sup>[8]</sup>: the adaptor "needs to wrap the associated executor, use this wrapping to wrap all submitted intermediate completion handlers, catch all exceptions thrown thereby, and coalesce them to `set_error_t(std::exception_ptr)`."<sup>[8]</sup> And so Leahy wraps the executor. His `completion_token`<sup>[2]</sup> defines an executor wrapper whose `execute` member function wraps every submitted invocable in a `run_` method that creates a frame (as we shall see in the following section) and catches all exceptions:
+The adopted wording creates a specific destruction boundary inside `let_value`. The boundary is narrower than the general completion rules and requires three lifetime concepts to remain separate.
+
+The **async lifetime** of an operation begins when `start` begins and ends when its completion operation begins. The associated **operation state** becomes invalid after completion executes. Its C++ object lifetime can continue beyond that point or end during completion. These are separate rules in `[exec.async.ops]`; completion does not generally destroy every operation-state object.<sup>[5]</sup>
+
+`let_value` adds an explicit object-lifetime operation. Its state contains a variant named `ops`. That variant initially contains the predecessor operation state. On a matching value completion, `[exec.let]` performs six steps:
+
+1. Store decayed copies of the predecessor's result datums in `args`.
+2. Replace the active `ops` alternative with `monostate`.
+3. Invoke the user-supplied factory with references to the stored copies.
+4. Connect the returned sender to the downstream receiver.
+5. Store the successor operation state in `ops`.
+6. Start the successor.
+
+The following excerpt is from the C++ draft source at commit `999d8ae0`, lines 4268-4277.<sup>[6]</sup>
 
 ```cpp
-template <typename F>
-void execute(T&& t) const noexcept
-{
-    self_.run_(
-        [&]() { ex_.execute(
-            wrap_(static_cast<T&&>(t))); });
-}
+auto& tuple =
+    args.emplace<args_t>(std::forward<Ts>(ts)...);
+ops.emplace<monostate>();
+auto&& sndr = apply(std::move(fn), tuple);
+using op_t = connect_result_t<sender_type, receiver_type>;
+auto mkop2 = [&] {
+    return connect(
+        std::forward<sender_type>(sndr),
+        receiver_type{rcvr, env});
+};
+auto& op = ops.emplace<op_t>(emplace-from{mkop2});
+start(op);
 ```
 
-Of course, the executive underlying the wrapper embodies whatever execution policy it embodies.<sup>[11]</sup> The work may be placed on a queue and later dequeued and invoked somewhere that is not underneath the wrapper on the call stack. And so it is insufficient to wrap on the outside; Leahy also intrudes inside `execute` and wraps therein as well.<sup>[11]</sup> Two associator specializations - `associated_executor` and `associated_allocator`<sup>[2]</sup> - inject this wrapping into AIO, causing AIO to use Leahy's executor logic at every level of analysis.<sup>[11]</sup>
+`variant::emplace` destroys the active alternative before constructing its replacement.<sup>[5]</sup> The first `ops.emplace` therefore destroys the predecessor operation state after the result copies exist but before the factory is invoked.
 
-But if throwing an exception can cause AIO to stop making forward progress on an operation, why do we imagine that throwing an exception is the only way in which AIO can be induced to stop making forward progress on an operation?<sup>[11]</sup>
+For default `let_value`, the adaptor wording defines the C++ object-lifetime boundary independently of the completion signal.
 
-## 4. Abandonment and the Frame Destructor
+## 3. Persisting a Descriptor Does Not Preserve Its Referent
 
-Leahy identifies a second category of forward-progress failure beyond exceptions. AIO supports what Leahy terms "abandonment" - one can "simply walk away from a running operation, allow the lifetime of the completion handlers to end, and everything is fine."<sup>[8]</sup> `std::execution` does not tolerate this.<sup>[8]</sup> For an operation which has been started, exactly one completion signal must be sent.<sup>[8]</sup>
+The result datum persisted by `let_value` can be an owner or a non-owning descriptor. That distinction determines whether persisting the datum also preserves the objects reached through it.
 
-The modal way that well-written AIO applications effectuate shutdown is to simply stop calling `run` on the execution context, let destructors run, never make forward progress on outstanding operations, and gracefully exit the scope.<sup>[11]</sup> This formulation works perfectly in AIO applications.<sup>[11]</sup> It does not work under structured concurrency, whereunder it is incumbent upon the bridge to detect abandonment and coalesce it to `set_stopped_t()`.<sup>[8]</sup>
+The standard defines `std::span` in `[span.overview]` as "a view over a contiguous sequence of objects, the storage of which is owned by some other object."<sup>[5]</sup> A span is trivially copyable. Copying it preserves a pointer and an extent; the copy does not copy the objects in the viewed sequence.
 
-And so Leahy builds the `frame_` class. His `operation_state_base`<sup>[2]</sup> in NVIDIA's stdexec reifies the above-described requirements as five members:
+P1179R1 uses the terms **Owner** and **Pointer** for this distinction. Its examples classify `string` and `vector` as Owners, while raw pointers, `string_view`, `span`, and `vector::iterator` are non-owning Pointers.<sup>[2]</sup> The terminology is broader than built-in pointer syntax because each listed type can remain alive after the object it denotes has been destroyed.
+
+### Terms Used in the Example
+
+- **Owner:** an object, such as `vector`, that owns the referenced byte storage.
+- **Descriptor:** a non-owning object, such as `span`, containing access information.
+- **Referent:** the byte sequence reached through the descriptor.
+- **Predecessor:** the operation whose result triggers `let_value`.
+- **Persisted result:** the decayed result object stored in `let_value::args`.
+- **Successor factory:** the callable that returns the next sender.
+
+Completion signatures provide a different category of information. `[exec.cmplsig]` permits `set_value_t(Vs...)`, `set_error_t(Err)`, and `set_stopped_t()`. A completion signature describes a completion operation through its tag and argument types.<sup>[5]</sup>
+
+Consider `set_value_t(std::span<std::byte>)`. The type states that successful completion sends a span. It does not identify whether the span refers to external storage, static storage, state owned by `let_value`, or state owned by its predecessor. A different completion datum can carry ownership: `vector`, `shared_ptr`, or an explicit owner token can make that property part of the result.
+
+`let_value` persists the completion datum it receives. When that datum is a span, persisting the span does not preserve storage owned by a different object.
+
+## 4. Identical Completion Signatures Can Have Opposite Validity
+
+Two predecessors isolate the ownership property. Each sends `std::span<std::byte>` through the value channel. The first stores the owner in its `then` callable; the second refers to an owner outside the sender.
+
+The following constructed sender stores the vector in the predecessor operation state after connection.
 
 ```cpp
-Receiver r_;
-asio_impl::cancellation_signal signal_;
-std::recursive_mutex m_;
-frame_* frames_{nullptr};
-std::exception_ptr ex_;
-bool abandoned_{false};
+auto ephemeral =
+    std::execution::just()
+    | std::execution::then(
+        [owner = std::vector<std::byte>(4096)]()
+            mutable noexcept {
+            return std::span<std::byte>(owner);
+        });
 ```
 
-A recursive mutex. An intrusive linked list of stack frames for lifetime tracking. An exception pointer. An abandonment flag. A stop callback (stored separately as an optional). The `frame_` destructor<sup>[2]</sup> implements structured concurrency finalization: If the current frame is the last frame on the linked list and the completion handler has been abandoned, it releases the lock and sends either `set_error` (if an exception was stored) or `set_stopped` (if no exception) through to the receiver. The `completion_handler` destructor<sup>[2]</sup> detects abandonment by creating a frame and setting the `abandoned_` flag to `true`.
+The `then` callable returns a valid span while its vector capture is alive. `let_value` receives that span, copies it into `args`, and replaces the predecessor operation state with `monostate`. Replacement destroys the `then` callable and its vector. The persisted span remains alive and denotes storage whose lifetime has ended.
 
-Note that Leahy's `frame_` destructor visits every branch of the state machine. Is the pointer null? Then the operation has already completed and there is no work to do. Otherwise: Remove the frame from the intrusive linked list. Compute whether this frame should finalize the operation. If there are no frames remaining and the handler has been abandoned, finalize.<sup>[11]</sup> Every path is enumerated. No branch is left unaddressed.
-
-This machinery maintains every invariant of structured concurrency. **The question the machinery raises is why these invariants require this much maintenance.**
-
-The equivalent machinery in a coroutine-native I/O library is a pre-allocated `resume_ctx` containing an executor reference and a continuation pointer, and a callback that posts the continuation to the executor.<sup>[9]</sup> No recursive mutex. No intrusive linked list. No abandonment flag. No frame destructor.
-
-But the bridge machinery is not the only place where Leahy's integration imposes structural costs. Let us examine what happens to the values themselves.
-
-## 5. The Channel Mapping and Partial Success
-
-AIO operations complete by invoking their completion handler with a leading error code and trailing arguments. A call to `async_read` delivers `(boost::system::error_code, std::size_t)` - the status and the byte count. Both values are always present. A read that returns `ECONNRESET` with 47 bytes means 47 bytes arrived before the peer reset the connection. The byte count is not redundant with the error code.
-
-The sender model provides three completion channels: `set_value`, `set_error`, and `set_stopped`. Leahy must route compound AIO results into discrete channels. His `use_sender`<sup>[3]</sup> defines a receiver whose `set_value` overload, when the first argument satisfies `is_error_code`, dispatches along three paths:
+The control changes only the owner's location.
 
 ```cpp
-void set_value(T&& t, Args&&... args)
-    && noexcept
-{
-    if (!t)
-    {
-        ::STDEXEC::set_value(
-            static_cast<Receiver&&>(r_),
-            static_cast<Args&&>(args)...);
-        return;
-    }
-    if (/* cancellation check */)
-    {
-        ::STDEXEC::set_stopped(
-            static_cast<Receiver&&>(r_));
-        return;
-    }
-    ::STDEXEC::set_error(
-        static_cast<Receiver&&>(r_),
-        use_sender::to_exception_ptr(
-            static_cast<T&&>(t)));
-}
+std::vector<std::byte> owner(4096);
+
+auto durable =
+    std::execution::just()
+    | std::execution::then([&owner]() noexcept {
+        return std::span<std::byte>(owner);
+    });
 ```
 
-On the first path (no error), the error code is stripped and the remaining arguments - including the byte count - are forwarded through `set_value`. On the second path (cancellation), `set_stopped` is sent and all arguments are discarded. On the third path (error), the error code is converted to `std::exception_ptr` and sent through `set_error`. The remaining arguments - including the byte count - are not forwarded. They are discarded.
+Destroying the second predecessor destroys a callable containing a reference. It does not destroy `owner`, so the persisted span remains usable while the external vector remains alive.
 
-Leahy recognized this structural tension in his initial review of the `use_sender` design<sup>[8]</sup>. He observed that the error-code-to-channel coalescing is "best left as a separate algorithm to ensure that 'partial success' has its context fully preserved."<sup>[8]</sup> The implementation thereof, however, coalesces truthy error codes to `set_error_t(std::exception_ptr)` and discards the remaining arguments, because the three-channel model affords no alternative which preserves both the error and the values transmitted thereby without routing I/O errors through `set_value`.
-
-The coroutine equivalent:
+Both `noexcept` callables return the same type. Their value completion signatures are therefore equal:
 
 ```cpp
-auto [ec, n] =
-    co_await stream.read_some(buf);
+using ephemeral_sigs =
+    std::execution::completion_signatures_of_t<
+        decltype(ephemeral), std::execution::empty_env>;
+using durable_sigs =
+    std::execution::completion_signatures_of_t<
+        decltype(durable), std::execution::empty_env>;
+
+static_assert(std::same_as<ephemeral_sigs, durable_sigs>);
 ```
 
-Both values. No channel to choose. No data lost. The application has the full compound result and decides what to do with it.
+The local environment has no C++26 compiler, so this assertion is presented as a deduction from the completion-signature rules rather than as an executed test.
 
-**Leahy's code discards the byte count on the error path. No mapping within the three-channel model preserves it.**
+Table 1. Matched predecessors with one completion signature and two owner locations.
 
-### 5.1. The Prescribed Algorithm
+| Property | Predecessor-owned case | External-owner control |
+|---|---|---|
+| Value completion | `set_value_t(span<byte>)` | `set_value_t(span<byte>)` |
+| Owner location | `then` callable in predecessor state | enclosing block |
+| Predecessor destruction | destroys the vector | destroys a reference capture |
+| Persisted span | refers to expired storage | refers to live storage |
 
-Leahy prescribed that the error-code-to-channel coalescing is "best left as a separate algorithm to ensure that 'partial success' has its context fully preserved."<sup>[8]</sup> Of course, the prescription is structurally sound - it identifies the correct layer at which the problem should be addressed, and it names the obligation precisely: The context of partial success must be preserved in its entirety.
+The matched pair differs in owner provenance, a property absent from their equal completion signatures.
 
-Which brings us to the question the prescription raises: What completion signature would such an algorithm produce?
+## 5. The Same Boundary Violates an Asynchronous I/O Precondition
 
-The algorithm is incumbent upon routing a compound result - an error code together with a byte count - through the channels available to it. And so it must choose. If the algorithm sends both values through `set_value` - that is, `set_value_t(error_code, size_t)` - then I/O errors travel the value channel, and downstream algorithms (`then`, `let_value`, `when_all`) cannot distinguish success from failure by channel alone. The semantic purpose of channel discrimination - the raison d'etre thereof - is defeated. Every consumer must inspect the error code manually, which is precisely the convention that obtained before channels existed.
+The matched pair becomes consequential when the successor is an asynchronous I/O operation. The three APIs examined below separate a pointer-size descriptor from storage that must remain alive until completion.
 
-If instead the algorithm preserves channel semantics by routing the error code through `set_error`, the byte count has no destination. `set_error` accepts a single argument. The operation state's lifetime ends at completion signal invocation (per P3373R2's<sup>[4]</sup> own formulation of operation state lifetimes). There is no storage thereunto which the byte count could be attached. There is no side channel. The data is destroyed at the abstraction floor.
+### 5.1. I/O Requires the Referent Through Completion
 
-And so the prescribed algorithm must choose between preserving data and preserving channel semantics. No formulation preserves both. The dilemma is not an engineering difficulty awaiting a sufficiently clever implementation. It is a structural consequence of the three-channel model applied to compound results.
+Boost.Asio 1.92.0 defines `mutable_buffer` as a copyable representation that "does not own the underlying data."<sup>[7]</sup> Its `basic_stream_socket::async_read_some` operation accepts one or more mutable buffers and returns immediately.<sup>[8]</sup> The parameter contract states:
 
-Kohlhoff identified this problem in P2430R0 (2021).<sup>[15]</sup> Five years and ten revisions of P2300 have elapsed. No algorithm has been published - not by Leahy, not by the P2300 authors, not in any sender library in the published record. Leahy's own merged implementation (PR #1503) ships the mapping that discards the byte count, because the three-channel model affords no alternative.
+> Although the buffers object may be copied as necessary, ownership of the underlying memory blocks is retained by the caller, which must guarantee that they remain valid until the completion handler is called.
 
-The coroutine model faces no such choice.
+The descriptor can therefore survive while its referent does not. The precondition applies from initiation through completion, the same interval for which the successor sender uses the buffer.
 
-But the channel mapping is not the only place where Leahy's published work identifies a structural cost of the sender model applied to I/O. Let us examine what Leahy found when he turned his attention to the algorithms themselves.
-
-## 6. Split: Allocation, Ownership, Eagerness
-
-Leahy's P3682R0<sup>[5]</sup> proposes removing `std::execution::split`. The paper identifies three deficiencies thereof.
-
-The first is dynamic allocation. A state must be dynamically allocated when a `split` sender is created, due to the fact it is shared by the original sender, all senders derived by copying the above, and all operation states derived by connecting either of the above.<sup>[5]</sup> Not only is this an issue due to the performance overhead of dynamic allocation, but the dynamic allocation occurs so early in the `std::execution` workflow (i.e. at sender creation time) that the allocation cannot be parameterized by the custom allocator provided by the receiver's environment (i.e. at connect time).<sup>[5]</sup>
-
-The second is shared ownership. The state associated with a `split` sender is shared, involving reference counting which can usually be avoided through structured concurrency.<sup>[5]</sup>
-
-The third is conditional eagerness. P2300R10<sup>[12]</sup> states that eager execution was removed from earlier revisions because it "has a number of negative semantic and performance implications."<sup>[12]</sup> Despite this, `std::execution::split` represents execution which is, conditionally and from certain points of view, eager.<sup>[5]</sup>
-
-Leahy's alternative is `let_value` composed with `when_all`:
+The public stdexec Asio adapter exposes `async_read_some` as a sender through `exec::asio::use_sender`.<sup>[9]</sup> The following constructed factory converts the persisted span to Asio's descriptor:
 
 ```cpp
-std::execution::sender auto shared =
-    /* ... */;
-(void)std::this_thread::sync_wait(
-    std::move(shared)
+auto read_from =
+    [&socket](std::span<std::byte>& buffer) {
+        return socket.async_read_some(
+            boost::asio::buffer(
+                buffer.data(), buffer.size()),
+            exec::asio::use_sender);
+    };
+```
+
+Applying that factory to the two predecessors from Section 4 produces two well-typed compositions:
+
+```cpp
+auto first =
+    std::move(ephemeral)
+    | std::execution::let_value(read_from);
+
+auto second =
+    std::move(durable)
+    | std::execution::let_value(read_from);
+```
+
+For `first`, the adopted order copies the span and destroys the vector owner before invoking `read_from`. The factory can copy the invalid pointer into an Asio descriptor, but the read cannot satisfy its requirement that the referenced memory remain valid through completion. Access through that descriptor has undefined behavior.
+
+For `second`, the same factory receives the same span type. The external vector remains alive, so the I/O precondition remains satisfied while the containing scope retains `owner`.
+
+Windows `ReadFileEx` independently requires its buffer to remain valid for the read duration.<sup>[10]</sup> Linux `io_uring(7)` states the same rule for pointers used by `IORING_OP_READ` and `IORING_OP_WRITE`.<sup>[11]</sup> These APIs use completion routines and completion queues rather than Asio completion tokens, yet impose the same owner-lifetime requirement.
+
+The hidden owner location determines whether equal sender metadata satisfies an ordinary asynchronous I/O precondition.
+
+## 6. Safe Ownership Placements Survive the Successor
+
+The adopted rule supports safe asynchronous I/O when the owner resides in state that remains alive through the successor. Three placements meet that condition without retaining the predecessor operation state.
+
+The first placement sends the owner itself into `let_value`. The adaptor moves the vector into its persisted argument storage before destroying the predecessor:
+
+```cpp
+auto safe_value =
+    std::execution::just(
+        std::vector<std::byte>(4096))
     | std::execution::let_value(
-        [](auto&&... values) {
-            return std::execution::when_all(
-                std::execution::just(
-                    std::ref(values)...)
-                | /* a */,
-                std::execution::just(
-                    std::ref(values)...)
-                | /* b */);
-        }));
+        [&socket](auto& owner) {
+            auto buffer = boost::asio::buffer(
+                owner.data(), owner.size());
+            return socket.async_read_some(
+                buffer, exec::asio::use_sender);
+        });
 ```
 
-No dynamic allocation. No shared ownership. No conditional eagerness. Leahy's proposal: "Remove `std::execution::split`. Replace it with nothing."<sup>[5]</sup> The committee agreed. SG1 forwarded. Plenary adopted.
+The successor depends on the vector stored in `let_value::args`. The destroyed `just` operation state owns no required storage. P2300R10 describes this use of `let_value`: the persisted sent object remains alive until the sender returned by the factory completes.<sup>[3]</sup>
 
-But `split` is not the only algorithm Leahy found to be doing more than its contract requires.
+The second placement stores the owner in the factory. P3373R4 deliberately leaves the callable alive because successor operations can depend on its captures.<sup>[1]</sup>
 
-## 7. When_all: The Ronseal Principle
+```cpp
+auto safe_capture =
+    std::execution::just()
+    | std::execution::let_value(
+        [&socket,
+         owner = std::vector<std::byte>(4096)]()
+            mutable {
+            auto buffer = boost::asio::buffer(
+                owner.data(), owner.size());
+            return socket.async_read_some(
+                buffer, exec::asio::use_sender);
+        });
+```
 
-Leahy's P3887R1<sup>[6]</sup> identifies that `std::execution::when_all` injects stopped completions for children that are not capable of sending stopped, belying the reasonable expectations of the consumer.<sup>[6]</sup> The algorithm does more than what it says on the tin - it is not, in Leahy's terminology, a "Ronseal algorithm."<sup>[6]</sup>
+The third placement lies outside the containing sender, as in the durable control of Section 4. Static storage, a caller-owned vector, or shared ownership can satisfy the same lifetime requirement when its owner outlives the operation.
 
-P2300R10<sup>[12]</sup> describes `when_all` thusly: "when_all returns a sender that completes once all of the input senders have completed."<sup>[12]</sup> This articulation, and the single responsibility which springs therefrom, have nothing to do with eager checking for stop requests - functionality which can be provided by a separate algorithm.<sup>[6]</sup> And so the consequence of the current formulation is that even given a set of child senders none of which send `set_stopped_t()`, a `when_all` sender unconditionally reports that it can send `set_stopped_t()`.<sup>[6]</sup>
+An owning completion datum provides another representation. A result type containing the vector, a `shared_ptr`, or an explicit owner token can make ownership part of the transmitted value. This changes the completion type, unlike the two matched span signatures.
 
-Were it the case that the additional behavior is advantageous or benign, the above might not be an issue. But operations which the user reasonably believed would be started and allowed to run are skipped,<sup>[6]</sup> which is germane to async scopes (which must be joined for correctness<sup>[6]</sup>) and to generalized async RAII. There is a narrower, less astonishing, Ronseal algorithm inside `std::execution::when_all`.<sup>[6]</sup> C++26 should ship that, not what is currently in the working draft.<sup>[6]</sup>
+The P3373R4 transition supports safe I/O when ownership is placed in argument storage, callable state, external state, or an owning result.<sup>[1]</sup>
 
-SG1 agreed (8-3-1-0-0). LEWG agreed (10-5-0-0-0).
+## 7. Coroutine Scope Makes the Compared Ownership Relation Lexical
 
-But the algorithmic corrections address individual symptoms. Let us examine one more observation before considering what the symptoms share.
+The comparable coroutine composition places the owner and the asynchronous operation in one block. Ordinary lexical scope expresses the lifetime relation without requiring knowledge of an adaptor's operation-state representation.
 
-## 8. The Language Change
+Boost.Asio 1.92.0 documents this pattern with a local array passed to `async_read_some` inside a coroutine loop.<sup>[12]</sup> The same shape with a vector is:
 
-Leahy's P3950R0<sup>[7]</sup> proposes that `return_value` and `return_void` are not mutually exclusive. The standard specifies that if searches for the names `return_void` and `return_value` in the scope of the promise type each find any declarations, the program is ill-formed.<sup>[7]</sup> This restriction has been present in its current form since N4499<sup>[13]</sup>. A different form thereof was present in N4403.<sup>[14]</sup>
+```cpp
+boost::asio::awaitable<void>
+read_once(tcp::socket& socket)
+{
+    std::vector<std::byte> owner(4096);
+    co_await socket.async_read_some(
+        boost::asio::buffer(
+            owner.data(), owner.size()));
+}
+```
 
-No task type in the intervening decade - cppcoro, folly::coro, libunifex's own task, TooManyCooks, Capy - has required this restriction to be removed.
+Automatic storage lasts until its block exits. `[expr.await]` specifies that suspension returns control to the caller or resumer "without exiting any scopes."<sup>[5]</sup> The vector therefore remains alive while the read is pending, provided the coroutine state itself remains alive.
 
-`std::execution::task` requires it to be removed. The library implementation of a function provided by `std::execution`'s senders and receivers is capable of completing successfully in multiple ways, obviating the need for a separate sum type<sup>[7]</sup> - but attempting to map `set_value_t()` (i.e. successful completion with no values) alongside any other `set_value_t(...)` form does not work, not for any conceptual reason, but simply because the standard bans it by fiat.<sup>[7]</sup>
+Coroutines can also dangle. Returning a descriptor into a local owner leaves the caller with an expired referent:
 
-Leahy identifies the restriction as fundamentally arbitrary, unnecessarily making `void` a special case.<sup>[7]</sup> Said restriction should for all the preceding reasons be removed.<sup>[7]</sup>
+```cpp
+task<std::span<std::byte>>
+bad()
+{
+    std::vector<std::byte> owner(4096);
+    co_return std::span<std::byte>(owner);
+}
+```
 
-**Leahy proposes changing the language. The language has not needed changing for any other task type.**
+Destroying a suspended coroutine state also destroys its local objects. The coroutine model does not infer ownership or extend a referent beyond its ordinary C++ lifetime.
 
-### 8.1. Two Obligations
+The comparison is therefore about visibility. In the coroutine control, block structure shows that the owner spans the `co_await`. In the sender witness, the owner sits in an ancestor operation state and the following adaptor supplies the destruction boundary.
 
-Both the coroutine-native task and `std::execution::task` are incumbent upon the same obligation: Furnish a well-formed promise type that maps the task's successful completion semantics into the coroutine language model. Let us examine how each discharges the obligation thereby imposed.
+## 8. Implementations Differ at the Factory Boundary
 
-**The coroutine-native task.** Given `task<T>` under the language rules as given:
+Two public implementations provide evidence about the transition. They agree that result datums are persisted and the predecessor state is replaced. They differ on whether replacement occurs before or after the successor factory invocation.
 
-- If `T` is `void`, the promise provides `return_void()`.
-- If `T` is not `void`, the promise provides `return_value(T)`.
-- The cases are mutually exclusive by the type parameter. The promise is well-formed. The obligation is discharged.
+The libunifex implementation cited by P3373R4<sup>[1]</sup> constructs a decayed result tuple, destroys `predOp_`, invokes the factory, connects the returned sender, and starts the successor.<sup>[13]</sup> Its source comment states that `predOp_` is destroyed first to make room for the successor operation. This order matches the adopted wording.
 
-Of course, the construction is unremarkable. The type parameter partitions the two cases and no further machinery is needful.
+NVIDIA stdexec at commit `2c56ffe7` invokes the factory while the predecessor owner remains alive, then replaces the predecessor before connecting and starting the successor.<sup>[14]</sup> A test named for destruction before factory invocation checks that a captured `shared_ptr` still has use count 2 inside the factory and has use count 1 after `start`.<sup>[15]</sup> The observed test condition documents the implementation order even though its name describes the standard order.
 
-**`std::execution::task`.** Given a task which must accommodate completion signatures `set_value_t()` and `set_value_t(T...)` simultaneously:
+### 8.1. The Normative Finding Does Not Depend on Either Ordering
 
-- The promise must provide `return_void()` for `set_value_t()`.
-- The promise must provide `return_value(T...)` for `set_value_t(T...)`.
-- Both names are thereby present in the promise type. Per [dcl.fct.def.coroutine]/p6, the program is ill-formed.
-- The obligation cannot be discharged under the rules as given.
-- Amend the rules: Adopt P3950R0.<sup>[7]</sup> Under the amended rules, both names may coexist. The promise is well-formed. The obligation is discharged.
+The code-equivalent wording controls the standard result: the predecessor is destroyed before the factory. A synchronous access to predecessor-owned bytes inside the factory can therefore be undefined under the wording while appearing to work in the pinned stdexec implementation.
 
-And so the obligation is fulfilled - but only after the language has been changed to permit it.
+The asynchronous I/O witness places the access later. In libunifex, the owner is gone before the factory. In the pinned stdexec implementation, the factory first returns an Asio sender containing the descriptor, then predecessor replacement destroys the owner before successor connection and start. The referenced bytes have expired in both implementations by the time the asynchronous child can access them.
 
-Leahy identifies the restriction as arbitrary, and the characterization is not in dispute. But the arbitrariness thereof and its significance as evidence are not in tension. An arbitrary restriction which lay dormant for a decade - encountered by no task type in cppcoro, folly::coro, libunifex, TooManyCooks, or Capy - was encountered by exactly one design. The encounter is germane precisely because the restriction is arbitrary: `std::execution::task` derives its return forms from the sender completion algebra rather than declaring them directly, and it is this derivation which creates the collision. A design that declares its return type is robust to arbitrary language restrictions. A design that derives its return type from an external algebra is not.
+The implementation comparison therefore bounds two claims. Factory-time behavior varies in the public implementations. Successor-time access still requires ownership that survives predecessor replacement.
 
-Which brings us to the question: Is it the restriction that is deficient, or is it the derivation?
+## 9. Expected Objections Bound the Finding
 
-## 9. What the Chain Reveals
+The constructed case admits direct objections. Four concern whether the program already violates an ordinary borrowing discipline. Four concern the scope of what follows from one default adaptor.
 
-The preceding sections trace an iterative chain of observations, each arising from the published work of one practitioner. Rather than iteratively discovering the whole problem domain, let us take a step back and look at the totality thereof.<sup>[11]</sup>
+### "The Predecessor Never Promised That Its Borrow Would Survive Completion"
 
-Six observations from Leahy's published work:
+Correct. The predecessor sends a span that is valid during its completion operation. Neither the span type nor the sender promises that the referent survives later destruction of the predecessor operation state.
 
-1. A bridge<sup>[2]</sup> that requires a recursive mutex, an intrusive linked list, structured concurrency finalization in the `frame_` destructor, abandonment detection in the `completion_handler` destructor, two associator specializations, and a wrapped executor - where the equivalent awaitable integration requires a pre-allocated context structure, a continuation node, and a callback.
+The relevant composition remains well-typed, and replacing the following `then` with `let_value` changes when the owner is destroyed. The claim concerns information available at that composition point and attributes no broken promise to the predecessor.
 
-2. A channel mapping<sup>[3]</sup> that discards the byte count on the error path because the three-channel model affords no mapping which preserves both the error code and the remaining arguments without routing I/O errors through `set_value`.
+### "Completion Signatures Were Never a Lifetime Type System"
 
-3. A recommendation<sup>[8]</sup> that partial success should have its context fully preserved, followed by an implementation that cannot preserve it within the constraints of the available channels.
+Correct. Completion signatures describe completion operations. Section 3 relies on that definition rather than assigning them a stronger purpose.
 
-4. An algorithm removed<sup>[5]</sup> for dynamic allocation at sender creation time (before the receiver's allocator is available), shared ownership via reference counting, and conditional eagerness. The committee agreed.
+Generic composition can inspect `set_value_t(std::span<std::byte>)` and cannot recover the omitted owner location from that type. An owning result or an explicit token can put additional lifetime information into the completion datum.
 
-5. An algorithm corrected<sup>[6]</sup> for injecting stopped completions that no child is capable of sending, belying the reasonable expectations of the consumer. The committee agreed.
+### "`span` Already Says That It Does Not Own"
 
-6. A core language change<sup>[7]</sup> needed by `std::execution::task` and by no other task type in a decade of coroutine libraries - not for any conceptual reason, but because the standard bans a simultaneous capability by fiat.
+The span type identifies the risk category. It does not identify whether the referent is external, static, stored in `let_value::args`, captured by the factory, or owned by the predecessor operation state. The matched pair in Section 4 differs among those locations while preserving the descriptor type.
 
-Each of the above is individually addressable. Leahy has addressed several of them; the committee has adopted or forwarded the remainder. But the question the totality raises is not whether each observation can be resolved in isolation. The question is what property the six observations share - what characteristic of the domain they occupy would cause a single practitioner, working from within the sender model, to encounter all six.
+### "This Is Ordinary C++ Dangling-View Behavior"
 
-**Six observations from one practitioner. One boundary.**
+The underlying object-lifetime rule is ordinary C++. The additional fact is where the owner dies. In the sender witness, the owner is nested in an operation state and its destruction is prescribed by the following adaptor rather than by a lexical block boundary.
 
-## 10. Falsification
+### "Putting the Owner in `let_value` Solves the Problem"
 
-The above-described observations would be discharged - that is, explained by causes other than a shared domain boundary - if any of the following were demonstrated:
+Yes. Section 6 shows two such constructions. They are evidence that sender-based I/O can satisfy the lifetime contract, and they identify the owner placement required by the adopted rule.
 
-- A sender design that achieves zero per-operation allocation under type erasure for byte-oriented I/O, matching the coroutine model's structural property documented in Section 4.
+### "A Domain Can Customize `let_value`"
 
-- A channel mapping that preserves both the error code and the byte count without routing I/O errors through `set_value`, matching the coroutine model's compound result documented in Section 5.
+Yes. The constructed proof concerns the default transformation and code-equivalent wording. A domain customization can select different storage and lifetime behavior, with that behavior becoming part of the domain's contract.
 
-- A motivation for P3950R0<sup>[7]</sup> that does not involve the sender channel model's interaction with coroutine promise types - that is, a reason the language restriction would need to be removed even if `std::execution::task` did not exist.
+### "Coroutines Can Dangle Too"
 
-- Evidence that `split`'s eagerness, dynamic allocation, and shared ownership served a use case within the sender model's natural domain (i.e. compute dispatch and heterogeneous scheduling) that has no alternative expression via `let_value` and `when_all`.
+Yes. Section 7 includes a coroutine returning a span into a local vector. The comparison concerns lexical visibility of the owner across one `co_await` and establishes no universal coroutine-safety result.
+
+### "The Example Does Not Cover Every `let_*` Adaptor"
+
+The ordinary buffer witness concerns `let_value`. `let_error` can carry one compound error datum that contains a non-owning view. `let_stopped` carries no result datum, so the same direct buffer-result construction does not apply.
+
+These objections limit the result to a well-typed default `let_value` composition whose predecessor owns the referent. They do not alter the ownership relations shown in Sections 2 through 5.
+
+## 10. Design Directions Trade Visibility Against Storage
+
+The evidence determines no unique remedy. Five directions expose different parts of the ownership relation and preserve different parts of P3373R4's storage result.<sup>[1]</sup>
+
+1. **Owner-placement conventions.** Library guidance can require owners to reside in `let_value` arguments, callable captures, or external state. This preserves the adopted wording and requires users to recognize the boundary.
+2. **Owning completion data.** APIs can send an owner, shared owner, or explicit lifetime token with the descriptor. This makes lifetime information available to composition and changes the completion type or ownership cost.
+3. **Diagnostics or ownership metadata.** Static analysis can track an Owner-to-Pointer relation of the kind described by P1179R1.<sup>[2]</sup> Such analysis requires information beyond an ordinary span completion signature.
+4. **Domain transformation.** An I/O domain can customize `let_value` or provide an adaptor with a domain-specific lifetime contract. This keeps generic wording unchanged and makes behavior depend on the selected domain.
+5. **Longer predecessor lifetime.** An adaptor can retain the predecessor through the successor. This preserves predecessor-owned borrows and gives up the storage reuse and earlier resource release that motivated P3373R4.<sup>[1]</sup>
+
+The five directions differ in ownership visibility, static storage reuse, generic metadata, and implementation cost. The evidence identifies the tradeoff without ranking those selections.
 
 ## 11. Conclusion
 
-Leahy's work demonstrates that the sender model maintains its invariants under I/O integration. The bridge works. The channel mapping works. The algorithmic corrections were adopted. The language change was proposed.
+Non-owning buffers are representable in sender completions, and `let_value` safely sequences I/O when the buffer owner resides in state that survives the successor. The adopted P3373R4 transition first persists the buffer descriptor, then destroys the predecessor operation state, then invokes the successor factory. When the destroyed state owns the descriptor's referent, an ordinary `set_value_t(std::span<std::byte>)` completion signature does not distinguish that dangling result from an equal signature whose referent remains alive. The resulting adaptor-specific ownership boundary is consequential for I/O while sender/receiver remains capable of representing I/O.
 
-The question the work raises is whether those invariants are the right ones for that domain.
+The record also identifies the tradeoff that produced the boundary. Earlier destruction permits predecessor and successor states to reuse storage and releases predecessor-held resources sooner. Longer lifetime preserves predecessor-owned borrows. Library authors can place owners in surviving state, domain authors can select different transformations, and lifetime-analysis tools can seek the owner relation that the ordinary descriptor type omits. Each builds on a separate part of the evidence rather than on a claim that one representation fits every asynchronous domain.
 
 ## Disclosure
 
 The author provides information and serves at the pleasure of the committee.
 
-The author developed and maintains [Capy](https://github.com/cppalliance/capy)<sup>[9]</sup> and [Corosio](https://github.com/cppalliance/corosio)<sup>[10]</sup>, coroutine-native I/O libraries under the C++ Alliance. The author has a stake in the coroutine model's adoption.
+The author developed and maintains [Capy](https://github.com/cppalliance/capy) and [Corosio](https://github.com/cppalliance/corosio) and believes coroutine-native I/O is a practical foundation for networking in C++.
 
 Coroutine-native I/O and `std::execution` are complementary. Each serves the domain where its design choices pay off.
 
-Coroutine-native I/O cannot express compile-time work graphs. This is a genuine limitation.
+This paper uses AI.
 
-This paper examines the published work of Robert Leahy - production code, WG21 papers, CppCon talks, and open-source review comments - and asks what his observations share. Every claim herein is sourced to Leahy's published work.
+The author has a stake in how C++ compares coroutine-native I/O with sender-based I/O. The analysis gives coroutine block scope a visibility advantage in one matched lifetime comparison.
+
+The constructed witness concerns default `let_value` and predecessor-owned storage. It does not measure the frequency of this pattern in deployed programs. The coroutine comparison in Section 7 addresses lexical visibility only; it does not compare compile-time inspection or optimization of a complete sender graph.
+
+Related work includes P3373R4, P2300R10, and the author's coroutine I/O papers. The method compares code-equivalent standard wording, equal-signature ownership controls, versioned I/O contracts, and pinned implementation sources.
 
 This paper asks for nothing.
 
-## Acknowledgements
+## Acknowledgments
 
-Robert Leahy, whose published work this paper examines in its entirety. Leahy's contributions to the sender model - production code in NVIDIA's stdexec, four WG21 papers adopted or forwarded by the committee, and CppCon talks whose constructive-proof methodology has informed this paper's argumentation - constitute the most thorough published examination of `std::execution`'s integration with existing asynchronous ecosystems. His exemplary work let us build proofs by iterative refinement: Construct the simplest version of a design, identify why it is wrong, fix it, discover what the fix breaks, and repeat until every path is covered and every invariant holds. This paper is indebted to Leahy's exhaustive public record and to the rigor with which he maintains it.
+The author thanks Robert Leahy for P3373R4 and its precise account of operation-state storage and lifetime choices; Herb Sutter for the Owner and Pointer vocabulary in P1179R1; and Christopher Kohlhoff for Boost.Asio's explicit asynchronous buffer-lifetime contract. The public libunifex and stdexec implementations made the ordering comparison reproducible.
 
 ## References
 
-[1] [NVIDIA/stdexec](https://github.com/NVIDIA/stdexec) - Reference implementation of `std::execution` (NVIDIA, 2024).
+[1] [P3373R4](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3373r4.pdf) - "Of Operation States and Their Lifetimes" (Robert Leahy, 2026).
 
-[2] [exec/asio/completion_token.hpp](https://github.com/NVIDIA/stdexec/blob/main/include/exec/asio/completion_token.hpp) - AIO-to-sender bridge (Robert Leahy, 2025).
+[2] [P1179R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1179r1.pdf) - "Lifetime safety: Preventing common dangling" (Herb Sutter, 2019).
 
-[3] [exec/asio/use_sender.hpp](https://github.com/NVIDIA/stdexec/blob/main/include/exec/asio/use_sender.hpp) - Sender completion token (Robert Leahy, 2025).
+[3] [P2300R10](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html) - "`std::execution`" (Micha&lstrok; Dominiak, Georgy Evtushenko, Lewis Baker, Lucian Radu Teodorescu, Lee Howes, Kirk Shoop, Michael Garland, Eric Niebler, Bryce Adelstein Lelbach, 2024).
 
-[4] [P3373R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3373r2.pdf) - "Of Operation States and Their Lifetimes" (Robert Leahy, 2025).
+[4] [N5047](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/n5047.html) - "Editors' Report: Programming Languages - C++" (Thomas K&ouml;ppe, Jens Maurer, Dawn Perchik, Richard Smith, 2026).
 
-[5] [P3682R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3682r0.pdf) - "Remove std::execution::split" (Robert Leahy, 2025).
+[5] [N5046](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/n5046.pdf) - "Working Draft, Programming Languages - C++" (Thomas K&ouml;ppe, 2026).
 
-[6] [P3887R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3887r1.pdf) - "Make when_all a Ronseal Algorithm" (Robert Leahy, 2025).
+[6] [C++ draft source](https://github.com/cplusplus/draft/blob/999d8ae0d2d3d6e76d85d39819cf253caacf6af6/source/exec.tex#L4268-L4277) - "`let_value` code-equivalent wording at commit `999d8ae0`" (ISO C++ project, 2026).
 
-[7] [P3950R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3950r0.pdf) - "return_value & return_void Are Not Mutually Exclusive" (Robert Leahy, 2025).
+[7] [Boost.Asio `mutable_buffer`](https://www.boost.org/doc/libs/1_92_0/doc/html/boost_asio/reference/mutable_buffer.html) - "A non-owning mutable buffer descriptor" (Christopher M. Kohlhoff, 2026).
 
-[8] [NVIDIA/stdexec PR #1501](https://github.com/NVIDIA/stdexec/pull/1501) - "Adapt boost::asio to stdexec" review comments (Robert Leahy, 2025).
+[8] [Boost.Asio `async_read_some`](https://www.boost.org/doc/libs/1_92_0/doc/html/boost_asio/reference/basic_stream_socket/async_read_some.html) - "Asynchronous socket read and buffer-lifetime requirements" (Christopher M. Kohlhoff, 2026).
 
-[9] [Capy](https://github.com/cppalliance/capy) (C++ Alliance).
+[9] [stdexec `use_sender.hpp`](https://github.com/NVIDIA/stdexec/blob/2c56ffe7f8a2b8b5221918159092be379ae8b40f/include/exec/asio/use_sender.hpp) - "Asio sender completion token at commit `2c56ffe7`" (NVIDIA, 2026).
 
-[10] [Corosio](https://github.com/cppalliance/corosio) (C++ Alliance).
+[10] [Microsoft `ReadFileEx`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfileex) - "Asynchronous file read and buffer-lifetime requirements" (Microsoft, accessed 2026-09-07).
 
-[11] [std::execution in Asio Codebases: Adopting Senders Without a Rewrite](https://www.youtube.com/watch?v=S1FEuyD33yA) - CppCon 2025 (Robert Leahy, 2025).
+[11] [`io_uring(7)`](https://man7.org/linux/man-pages/man7/io_uring.7.html) - "Linux asynchronous I/O interface" (Linux manual page, 2020).
 
-[12] [P2300R10](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html) - "std::execution" (Eric Niebler, Micha&lstrok; Dominiak, Lewis Baker, Lucian Radu Teodorescu, Lee Howes, Kirk Shoop, Michael Garland, Bryce Adelstein Lelbach, 2024).
+[12] [Boost.Asio C++20 coroutine support](https://www.boost.org/doc/libs/1_92_0/doc/html/boost_asio/overview/composition/cpp20_coroutines.html) - "C++20 Coroutines Support" (Christopher M. Kohlhoff, 2026).
 
-[13] [N4499](https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4499.pdf) - "Draft wording for Coroutines (Revision 2)" (Gor Nishanov, 2015).
+[13] [libunifex `let_value.hpp`](https://github.com/facebookexperimental/libunifex/blob/03a211667e7598311c6bdcefdb3d489d341a42f0/include/unifex/let_value.hpp#L150-L189) - "Predecessor replacement at commit `03a21166`" (Meta Platforms, 2025).
 
-[14] [N4403](https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4403.pdf) - "Draft wording for Resumable Functions" (Gor Nishanov, 2015).
+[14] [stdexec `__let.hpp`](https://github.com/NVIDIA/stdexec/blob/2c56ffe7f8a2b8b5221918159092be379ae8b40f/include/stdexec/__detail/__let.hpp#L259-L283) - "Successor construction at commit `2c56ffe7`" (NVIDIA, 2026).
 
-[15] [P2430R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2430r0.pdf) - "Partial success scenarios with P2300" (Chris Kohlhoff, 2021).
+[15] [stdexec `test_let_value.cpp`](https://github.com/NVIDIA/stdexec/blob/2c56ffe7f8a2b8b5221918159092be379ae8b40f/test/stdexec/algos/adaptors/test_let_value.cpp#L467-L485) - "`let_value` predecessor-lifetime test at commit `2c56ffe7`" (NVIDIA, 2026).

--- a/source/2026-09-september/d4255-synchronous-senders.md
+++ b/source/2026-09-september/d4255-synchronous-senders.md
@@ -1,7 +1,7 @@
 ---
-title: "Awaitables and Senders for Synchronous I/O"
+title: "Awaitables as the Natural Leaf Protocol for Coroutine-Centric Input/Output"
 document: P4255R0
-date: 2026-09-01
+date: 2026-09-07
 intent: info
 audience: SG1, LEWG
 reply-to:
@@ -10,11 +10,9 @@ reply-to:
 
 ## Abstract
 
-The sender protocol suspends a coroutine and constructs an operation state for a result that is already in memory; the awaitable protocol lets the operation check readiness and return.
+For coroutine-centric input/output (I/O), awaitables are the natural leaf protocol because sender-valued operations add a second composition model whose generic coroutine bridge lacks per-instance readiness.
 
-C++20 awaitables and `std::execution` senders are both consumed from coroutines through `co_await`, and both carry the same inherent suspension for an asynchronous operation; they differ when the operation completes synchronously - a buffered write, a cached read, bytes already in user-space memory before `co_await` evaluates. One synchronous write is traced through both protocols, with the sender granted every advantage the standard provides: the inline-completing sender the task type itself specifies, and a task environment that bypasses scheduler affinity. The awaitable fixture has work in three of the seven phases of `co_await`; Capy's erased stream forwards readiness and takes the same three-phase path when the stream reports ready, and the shipped paths that suspend have work in six, resuming by symmetric transfer. The generic `sender-awaitable` path has work in all seven, because its `await_ready` returns `false` unconditionally and `connect` has already run before readiness is asked. The cost recurs at every iteration of a composed I/O loop. A concrete sender can sidestep the generic path with its own `as_awaitable` member, but that customization is manual, per-sender, and lost under type erasure; lifting the cost from the protocol itself requires a readiness query, a direct value-extraction path, and virtual dispatch for type erasure - three mechanisms whose counterparts are `await_ready`, `await_resume`, and the awaitable's own function-table dispatch, on top of the `connect` and `start` the protocol already carries.
-
----
+Senders provide static composition, completion channels, operation ownership, environments, and structured concurrency, which sender-native consumers use directly. When a coroutine consumes a sender-valued I/O leaf through the generic bridge, translation adds connection, operation state, receiver completion, and an awaiter that always reports not ready. Custom awaiters, await-completion adaptors, domain transformations, and declared erased interfaces can select a different coroutine path, while completion-behavior queries and implementation techniques can reduce state and synchronization after a false readiness result. Branch 7.4 itself contains no pre-initiation query for whether a particular operation already holds a buffered result, whereas an awaitable exposes that decision directly.
 
 ## Revision History
 
@@ -22,608 +20,438 @@ C++20 awaitables and `std::execution` senders are both consumed from coroutines 
 
 - Initial revision.
 
----
-
 ## Introduction
 
-The comparison here is of what `co_await` executes when an I/O operation completes synchronously under two protocols: the C++20 awaitable protocol as constrained by the IoAwaitable protocol of P4003R3,<sup>[1]</sup> and the `std::execution` sender protocol consumed through `execution::task` as P3552R3<sup>[2]</sup> specifies it. No wording is proposed.
+C++ now has two standardized composition surfaces that meet at `co_await`. The coroutine language consumes an awaiter through readiness, conditional suspension, and extraction; `std::execution` constructs asynchronous operations through senders, receivers, connection, and start.<sup>[1]</sup> `execution::task` joins them by translating an awaited sender into an awaiter.<sup>[2]</sup>
 
-Related work. P3552R3 specifies `execution::task` and its `await_transform`; P3941R2<sup>[3]</sup> specifies scheduler affinity for it; P3796R1<sup>[4]</sup> collects open issues with the task type, affinity among them; P3206R0<sup>[5]</sup> proposes a query by which a sender advertises inline completion. P4088R1<sup>[6]</sup> examines the design fork between coroutine-native and sender-native I/O; P4093R1<sup>[7]</sup> and P4092R1<sup>[8]</sup> bridge awaitables into sender pipelines and senders into coroutine-native code; P4126R1<sup>[9]</sup> removes the bridge's allocation.
+P2300R10 defines the sender model and its generic sender-to-awaitable bridge.<sup>[3]</sup> P2257R0 and P3206R0 examine completion timing, with P3206R0 proposing static, environment-dependent, and dynamic completion behavior.<sup>[4]</sup><sup>[5]</sup> P3570R2 supplied the composition case that led to the forwarding await-completion adaptor now in the working draft.<sup>[6]</sup> P3552R3, P3796R1, and P3941R4 develop task integration, stack bounding, and scheduler affinity.<sup>[2]</sup><sup>[7]</sup><sup>[8]</sup>
 
-Contributions:
+Coroutine control transfer has its own history. P0913R1 added symmetric coroutine transfer, P1056R1 applied it to lazy tasks, and P2583R4 examines its absence from intermediate sender receivers.<sup>[9]</sup><sup>[10]</sup><sup>[11]</sup> P3801R0 separately identifies recursive behavior when sender completions resume task coroutines inline.<sup>[12]</sup> P4003R3 defines the IoAwaitable protocol used here, while P4092R1, P4093R1, and P4126R1 examine both bridge directions and their continuation requirements.<sup>[13]</sup><sup>[14]</sup><sup>[15]</sup><sup>[16]</sup>
 
-1. A phase-by-phase trace of one synchronous write under both protocols, with senders in the most favorable configuration the standard provides (Sections 5-7).
-2. A record of how the shipped awaitable libraries handle the synchronous case and the cost they carry for it (Section 6).
-3. The composed-I/O multiplier that makes the per-operation difference recur (Section 10).
-4. The modifications the sender protocol would need to match the awaitable protocol on this case, and a survey of the mechanisms that exist today (Section 11).
+1. A vocabulary separating synchronous completion, inline completion, per-instance pre-start readiness, and a coroutine fast path.
+2. A side-by-side account of the language awaiter surface and the sender-to-awaitable translation surface.
+3. A normative trace that includes every `as_awaitable` branch and the implementation freedom available to standard-library senders.
+4. Three I/O fixtures separating an already-materialized result, completion discovered during initiation, and a pending operation.
+5. A survey of completion behavior, await-completion adaptation, domain transformation, composition, erasure, and two public implementations.
 
-Assumptions. The sender trace follows the working draft N5054<sup>[10]</sup> and P3552R3,<sup>[2]</sup> with the task's environment naming `inline_scheduler` under both spellings of that knob (`scheduler_type` in P3552R3, `start_scheduler_type` in the working draft) so that no affinity cost is counted. The unit of comparison is the phase, defined in Section 5. No heap-allocation elision is assumed on either side. Runtime cost is measured only where Section 11.5 says so; elsewhere the comparison is of what the protocols specify.
+The scope is coroutine-centric I/O: operations whose primary consumer is a coroutine body and whose higher-level buffering can make a result available before initiation. Sender-native pipelines, direct receiver consumers, and system calls whose completion becomes known only during initiation remain in the comparison but are not covered by the central conclusion.
 
-## 1. The Abstraction
+The term "natural leaf protocol" has four criteria: direct language integration, a per-instance readiness decision, one operation representation for coroutine consumption, and no sender-to-awaitable translation layer. The criteria are the author's analytical standard and are applied to both protocols in Table 2. The author maintains awaitable-native libraries and has a professional interest in the result. If a delegate rejects the word "natural" or these criteria, the normative fallback finding remains: branch 7.4 connects before readiness and returns `false` from `await_ready` for every instance.<sup>[1]</sup>
 
-A synchronous write stream has one operation: Accept a string and store it. It offers no error codes, byte counts, or partial writes. The abstraction is intentionally minimal: a test fixture that isolates the protocol's behavior from the I/O operation's complexity. Two concrete types implement it.
+"Wording burden" means additional standardized entities and semantic interactions. It does not mean generated runtime cost.
 
-`string_sink` appends to a `std::string`. The operation is synchronous, the data is already in memory, and no kernel transition occurs.
+N5054 and the current public draft rendering supply the normative basis.<sup>[1]</sup> Source claims use immutable stdexec and Beman.Execution commits from September 2026. Phase counts are not used as a performance model, and no benchmark result is used as evidence.
+
+## Sender Composition Solves a Different Problem
+
+Sender and receiver provide a general model for constructing and composing asynchronous operations. The properties that make that model useful remain relevant when its coroutine-consumption path is examined.
+
+The sender model provides static composition. Adaptors such as `then`, `let_value`, and `when_all` form typed work graphs whose connected operation state owns the state of its children. P2300R10 describes the performance requirement as avoiding allocations and indirections in generic asynchronous algorithms expected on hot paths.<sup>[3]</sup> This is a property of sender-native composition rather than of one leaf operation.
+
+The model also provides three completion channels. A receiver accepts value, error, or stopped completion, and completion signatures describe those possibilities for a sender in an environment. Environments provide schedulers, allocators, stop tokens, and domain information used to transform or execute the operation. The native protocol therefore describes more than suspension and resumption.
+
+Operation states give the connected operation a lifetime. The working draft says that connecting a sender and receiver creates an asynchronous operation, while `start` begins it.<sup>[1]</sup> Destroying an operation state while its operation is still live has undefined behavior. This ownership boundary is necessary when work remains pending after initiation.
+
+The model permits an asynchronous operation to execute synchronously. The working draft states that an operation can complete during `start` on the starting thread, and `inline_scheduler` completes by calling `set_value` directly from `start`.<sup>[1]</sup> Synchronous execution is therefore part of the sender model.
+
+Structured concurrency is another sender-side facility. The counting-scope facilities track associated work and require the scope to reach an allowed state before destruction; premature destruction invokes `terminate` rather than preventing destruction.<sup>[1]</sup><sup>[17]</sup>
+
+Sender-native composition provides static work graphs, explicit completion channels, operation ownership, environmental customization, and structured concurrency. The awaitable leaf protocol does not replace those properties.
+
+## Completion and Readiness Are Different Properties
+
+Synchronous execution is not one property. Four separate properties determine what a coroutine can avoid, and using one name for all four conflates distinct protocol properties.
+
+| Term | Meaning in this analysis |
+| --- | --- |
+| **Synchronous completion** | The operation executes a completion operation before `start()` returns. |
+| **Inline completion** | The operation completes before `start()` returns on the execution agent that called `start()`. |
+| **Per-instance pre-start readiness** | This operation object already has its result before initiation, although another object of the same type may not. |
+| **Coroutine fast path** | The coroutine obtains the result without being considered suspended by `[expr.await]`. |
+| **Awaiter** | The object on which the language evaluates `await_ready`, `await_suspend`, and `await_resume`. |
+| **Operation state** | The object produced by connecting a sender and receiver and passed to `start`. |
+
+Table 1. The four completion properties and the two protocol objects used throughout the comparison. The definitions separate completion discovered during initiation from a result known before initiation.
+
+The working draft defines synchronous completion through timing relative to `start`.<sup>[1]</sup> Different instances of one sender type may complete during `start` or later. The definition does not provide a pre-start result or a way for a coroutine to ask whether one exists.
+
+The coroutine language asks a different question. After promise transformation and awaiter selection, `[expr.await]` evaluates `await_ready()` before deciding whether the coroutine is considered suspended.<sup>[1]</sup> A true result proceeds to `await_resume`; a false result enters the suspension path and evaluates `await_suspend`. The result is a property of the awaiter object, so two objects of the same type can return different values.
+
+P3206R0 proposes completion behavior as a sender attribute.<sup>[5]</sup> Its categories describe whether receiver completion occurs before `start` returns and whether it occurs inline. The proposal permits static type information, environment-dependent queries, and a dynamic result for `split` after its shared operation has completed. It contains no wording, and the working draft's generic sender awaiter does not query it.
+
+Completion behavior and pre-start readiness can correlate without being equivalent. A sender may guarantee inline completion because `start` performs work immediately, even though no result exists beforehand. Conversely, a shared or cached operation may already hold a result and still expose that result through `start` and receiver completion.
+
+Synchronous completion, inline completion, per-instance readiness, and a coroutine fast path are four distinct properties. Only the third represents whether a particular result is already available before initiation.
+
+## Awaitables and Senders Expose Different Consumption Surfaces
+
+The two protocols expose different surfaces to a coroutine consumer. The protocol difference concerns specification structure and semantic obligations; entity counts do not establish runtime cost.
+
+An awaitable reaches the language through one awaiter. The language evaluates `await_ready`, conditionally evaluates `await_suspend`, then evaluates `await_resume`.<sup>[1]</sup> P4003R3 extends the suspend member with an I/O environment that provides executor, stop-token, and allocator information, while retaining the same readiness and extraction boundary.<sup>[13]</sup>
+
+A sender reaches the same language protocol after a second composition model has been translated. A compatible sender describes completion signatures in an environment, transforms through its domains, may acquire scheduler affinity, may apply an await-completion adaptor, connects to a receiver, stores a resulting operation state, starts it, accepts one completion channel, stores the result for the coroutine, and finally presents an awaiter to `[expr.await]`.<sup>[1]</sup> Each mechanism provides a sender property; the translation is additional only for a coroutine consumer.
+
+| Concern | Awaitable leaf | Sender-valued leaf awaited by `execution::task` | Sender capability provided |
+| --- | --- | --- | --- |
+| Result alternatives | `await_resume` return or throw | Completion signatures and value, error, stopped channels | Generic composition over completion alternatives |
+| Consumer context | Promise and I/O environment | Receiver environment, sender attributes, domains, task promise | Scheduler, allocator, cancellation, and domain customization |
+| Operation creation | Awaiter construction | `connect(sender, receiver)` produces an operation state | Separate graph construction from activation |
+| Activation | `await_suspend` when not ready | `start(operation_state)` from the bridge's `await_suspend` | Uniform lazy start |
+| Pre-suspension decision | `await_ready()` on this awaiter object | Custom awaiter, or fixed `false` in the generic fallback | The native sender protocol specifies completion timing instead |
+| Coroutine translation | None after awaiter selection | `await_transform`, optional `affine`, `as_awaitable`, transformation, adaptation, then awaiter selection | Interoperation with sender-valued expressions |
+
+Table 2. The protocol surfaces used when a coroutine consumes an awaitable leaf or a sender-valued leaf. The right column records why the sender mechanism exists; the table measures wording requirements and semantic obligations rather than generated instructions.
+
+A sender pipeline uses completion signatures, connection, and receiver channels directly. A coroutine body already supplies sequencing, lifetime, and conditional suspension, so sender-valued I/O must cross both protocol surfaces before the language can consume it.
+
+Awaitables expose per-instance readiness directly, while the native sender path exposes completion after an operation has been connected and started.
+
+## The Generic Bridge Has No Per-Instance Readiness Branch
+
+The working draft provides five routes from an expression to an awaiter. The generic sender fallback is only the last sender-specific route, and its exact placement prevents the trace from being generalized to every conforming sender.
+
+Inside `execution::task`, `await_transform` first handles scheduler affinity. If the task's `start_scheduler_type` is `inline_scheduler`, it passes the sender directly to `as_awaitable`; otherwise it applies `affine` first.<sup>[1]</sup><sup>[2]</sup> Affinity is therefore a separate concern from readiness.
+
+`as_awaitable(expr, promise)` then selects among five ordered results:<sup>[1]</sup>
+
+1. The expression's own `as_awaitable` member.
+2. An `as_awaitable` member on the transformed and await-completion-adapted sender.
+3. The original expression when it is already an awaiter.
+4. The exposition-only `sender-awaitable` for a compatible single-value sender.
+5. The original expression otherwise.
+
+The first three routes can avoid the generic bridge. The second route applies `transform_sender` before consulting the forwarding `get_await_completion_adaptor` query, so a domain or attribute adaptor can supply a common coroutine representation for more than one concrete sender type.
+
+The fourth route constructs the exposition-only `sender-awaitable`. Its relevant shape is:
 
 ```cpp
-class string_sink
-{
-    std::string& out_;
+variant<monostate, result-type, exception_ptr> result{};
+connect_result_t<Sndr, awaitable-receiver> state;
 
-public:
-    explicit string_sink(std::string& s)
-        : out_(s) {}
-
-    auto write(std::string_view sv)
-    {
-        out_.append(sv.data(), sv.size());
-        // returns an awaitable or sender
-    }
-};
+sender-awaitable(Sndr&& sndr, Promise& p);
+static constexpr bool await_ready() noexcept { return false; }
+void await_suspend(coroutine_handle<Promise>) noexcept { start(state); }
+value-type await_resume();
 ```
 
-`tcp_sink` writes to a TCP socket. The operation is asynchronous. The kernel accepts the data, the coroutine suspends, and the reactor resumes it when the write completes.
+This is working-draft exposition from `[exec.as.awaitable]`.<sup>[1]</sup> The constructor initializes `state` with `connect`, so connection precedes the language's readiness question. `await_ready()` then returns `false` for every object. `await_suspend()` starts the operation.
 
-Both expose the same `write(std::string_view)` signature. The return type differs, but the algorithm that calls `co_await sink.write(...)` does not.
+Completion reaches an `awaitable-receiver`. Value or error completion emplaces a result or exception in the stored variant, then evaluates `continuation.resume()`; stopped completion resumes the handle selected by the promise's `unhandled_stopped` operation.<sup>[1]</sup> `await_resume()` rethrows the stored exception or extracts the stored value. The variant is a subobject whose alternative is emplaced; its presence does not imply heap allocation.
 
-## 2. Recompilation
+`[expr.await]` considers the coroutine suspended before evaluating `await_suspend`.<sup>[1]</sup> An implementation may optimize generated code when observable behavior permits, but phase counting does not establish the resulting instruction or latency cost.
 
-The awaitable protocol provides two mechanisms for handling synchronous I/O without changing the algorithm's source. The first is recompilation: The same coroutine template compiled against different sink types produces different execution models.
+Standard-library sender types have additional implementation freedom. `[exec.snd.expos]/2` makes it unspecified whether a standard-library sender provides `sndr.as_awaitable(p)` and requires any such expression to meet `as_awaitable` semantics.<sup>[1]</sup> A conforming implementation can therefore give `inline-sender` a member that selects the first branch. Portable code cannot require that member.
 
-The following illustrative algorithm writes a span of lines to a generic sink:
+The generic fallback connects before readiness, reports false readiness, starts from `await_suspend`, and completes through its receiver. Those statements describe branch 7.4 only.
+
+## Three I/O Cases Locate the Boundary
+
+Three I/O shapes separate a result known before suspension from completion discovered during initiation. The distinction prevents an eager fixture from standing in for every synchronous I/O operation.
+
+### A result produced before the operation object returns
+
+The smallest fixture performs an in-memory append before returning its awaitable or sender:
 
 ```cpp
-template<class Sink>
-task<> log_lines(Sink& sink,
-    std::span<std::string_view> lines)
+auto write(std::string_view text)
 {
-    for (auto line : lines)
-        co_await sink.write(line);
+    out_.append(text.data(), text.size());
+    // Return an immediate awaitable or inline-completing sender.
 }
 ```
 
-If one compiles against `tcp_sink`, the awaitable returned by `write` suspends, the reactor resumes, and the algorithm is asynchronous. If one recompiles against `string_sink`, the awaitable returned by `write` has `await_ready() == true`, no suspension occurs, and the algorithm is synchronous.
+This is hypothetical fixture code. It isolates consumption of an already-produced, value-less result. An immediate awaitable returns `true` from `await_ready`; an inline sender reports completion from `start`. If the sender reaches the generic fallback, the language still receives false readiness.
 
-The source is identical, but the awaitable type varies. The execution model is selected at compile time.
+The fixture is intentionally narrow. The append occurs even when the returned operation object is discarded, so it does not represent the lazy execution convention of standard sender adaptors. Its result concerns protocol consumption after work has already happened.
 
-## 3. Relinking
+### Completion discovered during initiation
 
-The second mechanism is relinking: The linker selects the execution model for an algorithm compiled once against a type-erased stream. Where recompilation varies the template argument, relinking varies the object file behind a function table.
+Overlapped `WSARecv` supplies a sender-native mixed-completion example. Microsoft specifies that return zero means the operation completed immediately, while `SOCKET_ERROR` with `WSA_IO_PENDING` means successful initiation followed by later completion.<sup>[18]</sup> P2300R10 contains one `recv_sender` type whose `start` handles both outcomes.<sup>[3]</sup>
 
-The following illustrative algorithm compiles against a type-erased stream. The shape follows Capy's `any_write_stream`:<sup>[11]</sup> `write` is not itself virtual, because a virtual function cannot return an implementation-specific awaitable type; it returns a fixed awaitable that calls through a function table. Capy's table is a struct of function pointers, not a C++ virtual table; this paper says function table for it and reserves virtual for the hypothetical sender base of Section 11.5:
+The sender protocol directly represents this operation. `start` calls `WSARecv`; immediate success calls `set_value`, while the operation state for a pending result persists until completion-port processing. P2300R10's immediate branch assumes `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS`, which suppresses the completion-port entry that an immediate operation would ordinarily produce.<sup>[19]</sup> The operation result does not exist before initiation, so true pre-start readiness is unavailable.
 
-```cpp
-class write_stream
-{
-    struct vtable;
-    void* impl_;            // the concrete stream
-    vtable const* vt_;      // its function table
-    void* cached_;          // storage for its awaitable, allocated once
+An awaiter handles the same distinction from `await_suspend`. It initiates `WSARecv`, stores an immediate result when return zero is observed, then returns `false` or transfers directly to the continuation. For a pending result, the coroutine remains suspended. Both implementations need stable state and a race-safe handshake when completion can occur concurrently with initiation.
 
-public:
-    // returns an IoAwaitable that calls through vt_
-    auto write(std::string_view sv);
-};
+Socket readiness does not convert this case into pre-start completion. Microsoft warns that a readiness event can be followed by a receive returning `WSAEWOULDBLOCK`.<sup>[20]</sup> Readiness predicts whether initiation might complete; it is not the result of a particular receive.
 
-task<> log_lines(write_stream& sink,
-    std::span<std::string_view> lines)
-{
-    for (auto line : lines)
-        co_await sink.write(line);
-}
-```
+### A user-space result ready in one instance and pending in another
 
-The algorithm's object code is fixed. It is identical whether the stream behind the function table is synchronous or asynchronous, and nothing in it distinguishes the two cases.
+A buffered stream supplies the pre-start case. One `read_some` object may find enough bytes in a user-space buffer, while another object of the same type must initiate an asynchronous receive. The cache-hit result can be copied and counted before suspension is considered.
 
-If one links against an object file that provides `tcp_sink` behind the function table, the algorithm is asynchronous. If one links against a different object file that provides `string_sink` behind the function table, the algorithm is synchronous.
-
-Relinking requires no recompilation and costs zero allocations per write: The concrete stream's awaitable is constructed into storage the erased stream allocated once. The erased awaitable constructs the concrete awaitable inside its own `await_ready()` (Capy commit `9200ddc`) and forwards the answer. A ready stream completes without suspending, through four function-table calls (`construct_awaitable`, `await_ready`, `await_resume`, `destroy_awaitable`) and no scheduler. A pending stream suspends, a fifth call, `await_suspend`, forwards through the table, and the coroutine resumes by symmetric transfer - `await_suspend` returning the handle to resume, so the resumption is a tail call rather than a nested one. On either path no operation state, receiver, or nested resume exists. The algorithm was compiled once, and the execution model was chosen by the linker.
-
-## 4. What Senders Provide
-
-Before examining the sender path for synchronous I/O, this section records three properties `std::execution` provides that the awaitable protocol does not.
-
-1. **Zero-allocation composition.** Sender pipelines collapse into a single `operation_state` at compile time. No heap allocation, virtual dispatch, or reference counting occurs. Coroutines do not match this property for multistage pipelines.<sup>[12]</sup>
-
-2. **Compile-time work graphs.** The sender algebra encodes directed acyclic graphs (DAGs) of work at the type level. `when_all`, `then`, and `let_value` compose into a static structure the optimizer can see through. Domain customization via `transform_sender` retargets the same graph to CPU or GPU by swapping the scheduler.<sup>[13]</sup>
-
-3. **Structured concurrency.** `counting_scope` tracks dynamically spawned work and prevents scope destruction until all work completes.<sup>[14]</sup>
-
-The comparison that follows grants senders every advantage the standard provides. The sender is `inline_scheduler::schedule()`, the facility the working draft specifies for inline completion (`[exec.inline.scheduler]`);<sup>[10]</sup> that choice carries the minimal completion signature, `completion_signatures<set_value_t()>`, and synchronous completion inside `start`, both specified there. The task's environment names `inline_scheduler` as its scheduler type, so that `await_transform` skips the affinity wrapping (`affine_on` in P3552R3 `[task.promise]` p10; `affine` in the working draft `[task.promise]` p6) and no scheduler affinity step is counted. The `sender-awaitable` path that remains is imposed by the sender protocol on every sender that neither provides its own `as_awaitable` member nor supplies an await-completion adaptor, and on every sender consumed through `any_sender`, which erases both (Section 12). `any_sender` is this paper's name for the erased sender wrappers libraries ship, such as stdexec's `any_sender` (header `exec/any_sender_of.hpp`);<sup>[13]</sup> the working draft specifies none.
-
-## 5. The Sender Path
-
-Sections 2 and 3 showed the awaitable protocol's two mechanisms for synchronous I/O. This section traces the sender protocol's path for the same operation, a synchronous write to an in-memory string, using the best-case sender the standard provides.
-
-Both traces use the same unit. A phase is one stage of `co_await` that the protocol's specification names: transform, connect, readiness, suspend, launch, complete, extract. Each trace lists all seven; a protocol with no work in a phase says so. The unit is the phase rather than the function call, so that wrapper forwarding on either side (a `transform_awaiter` calling through to the awaitable it wraps, a `sender-awaitable` calling `connect`) does not change the count. Four of the names are `[expr.await]`'s own stages (transform, readiness, suspend, extract); three are the sender protocol's (connect, `start` - called launch here - and completion), and a protocol that has no such stage leaves the phase empty. The sender's launch and complete phases both run inside the awaitable's suspend stage, which is why the sender-named phases are listed separately: The count is of protocol stages, and it is stated so that a reader who prefers `[expr.await]`'s four can recount. A readiness check counts as work whatever it answers, on both sides.
-
-`string_sink::write` returns the sender produced by `inline_scheduler::schedule()`, the exposition-only `inline-sender` type the working draft specifies at `[exec.inline.scheduler]`:<sup>[10]</sup>
+The following illustrative projections share one operation implementation:
 
 ```cpp
-class string_sink
-{
-    std::string& out_;
-
-public:
-    explicit string_sink(std::string& s)
-        : out_(s) {}
-
-    auto write(std::string_view sv)
-    {
-        out_.append(sv.data(), sv.size());
-        return std::execution::
-            inline_scheduler{}.schedule();
-    }
-};
-```
-
-The sender's `start` calls `set_value` on the receiver immediately. No kernel transition occurs, and the sender side does not suspend. This sender is not a hand-rolled type; it is the one the working draft<sup>[10]</sup> specifies for inline completion.
-
-A coroutine returning `execution::task` consumes it. The task's environment names `inline_scheduler` so that `[task.promise]` p10 skips affinity wrapping; the default environment uses `task_scheduler` and would wrap every awaited sender in `affine_on`:<sup>[2]</sup>
-
-```cpp
-struct inline_env
-{
-    // P3552R3 names the knob scheduler_type; the working draft names it
-    // start_scheduler_type. Declaring both satisfies either text.
-    using scheduler_type       = execution::inline_scheduler;
-    using start_scheduler_type = execution::inline_scheduler;
-};
-
-execution::task<void, inline_env> log_lines(
-    string_sink& sink,
-    std::span<std::string_view> lines)
-{
-    for (auto line : lines)
-        co_await sink.write(line);
-}
-```
-
-The working draft<sup>[10]</sup> and P3552R3<sup>[2]</sup> describe what happens inside `co_await sink.write(line)`:
-
-1. Transform. `await_transform` receives the sender. P3552R3 `[task.promise]` p10 checks `same_as<inline_scheduler, scheduler_type>`;<sup>[2]</sup> the working draft `[task.promise]` p6 checks `same_as<inline_scheduler, start_scheduler_type>`.<sup>[10]</sup> The task's environment satisfies both, so the affinity wrapper (`affine_on` in P3552R3, `affine` in the working draft) is bypassed and `as_awaitable(sndr, *this)` is returned directly.
-
-   `as_awaitable` then applies `transform_sender(sndr, get_env(p))` and `adapt-for-await-completion`, which queries `get_await_completion_adaptor` on the sender's environment and applies the adaptor when one is present; `inline-sender` supplies none, so the sender passes through unchanged. A `sender-awaitable` is constructed from the result (`[exec.as.awaitable]` p7-p8).<sup>[10]</sup>
-
-2. Connect. The `sender-awaitable` constructor calls `connect(sndr, awaitable-receiver)`.<sup>[10]</sup> The operation state is materialized, and the receiver is wired.
-
-3. Readiness. `await_ready()` returns `false` unconditionally.<sup>[10]</sup>
-
-4. Suspend. The coroutine suspends.
-
-5. Launch. `await_suspend` calls `start(state)`.<sup>[10]</sup> Inside `start`, `set_value(receiver)` fires synchronously.
-
-6. Complete. The receiver stores the result in a `variant` and calls `.resume()` on the coroutine handle, nested inside `await_suspend`.<sup>[10]</sup> The coroutine resumes.
-
-7. Extract. `await_resume()` reads the value from the `variant`.<sup>[10]</sup>
-
-All seven phases have work. For an operation that completes synchronously, the path incurs one suspension and one resumption, one operation state construction, one receiver instantiation, and one `variant` emplacement; only the scheduler affinity wrapping is avoided.
-
-The bypass in the transform phase belongs to the task's environment: Every sender awaited from a task whose environment names `inline_scheduler` skips `affine_on`, a user-defined synchronous sender included.<sup>[2]</sup> Under the default environment the same `co_await` wraps the sender in `affine_on`<sup>[3]</sup> (P3941R2, "Scheduler Affinity," which specifies scheduler affinity enforcement for sender-based coroutines) and adds that operation's cost. Seven phases is therefore the floor for any sender that neither customizes `as_awaitable` nor supplies an await-completion adaptor (Section 4), in the most favorable task configuration the standard provides.
-
-## 6. The Awaitable Path
-
-The same operation traced through the awaitable protocol. Where Section 5 returned a sender from `write`, this section returns an IoAwaitable - a type satisfying the three-member protocol defined in P4003R3<sup>[1]</sup> (a minimal coroutine execution model that specifies executor affinity, stop-token propagation, and frame-allocator delivery for coroutines).
-
-`string_sink::write` returns an IoAwaitable:
-
-```cpp
-class string_sink
-{
-    std::string& out_;
-
-public:
-    explicit string_sink(std::string& s)
-        : out_(s) {}
-
-    auto write(std::string_view sv)
-    {
-        out_.append(sv.data(), sv.size());
-        return immediate{};
+struct buffered_read_awaiter {
+    bool await_ready() {
+        return stream.try_read(buffer, result);
     }
 
-private:
-    struct immediate
-    {
-        bool await_ready() const noexcept
-        {
-            return true;
-        }
-
-        void await_suspend(
-            std::coroutine_handle<>,
-            io_env const*) noexcept
-        {
-        }
-
-        void await_resume() noexcept {}
-    };
-};
-```
-
-A coroutine returning a task type that satisfies the IoAwaitable protocol<sup>[1]</sup> consumes it:
-
-```cpp
-task<> log_lines(
-    string_sink& sink,
-    std::span<std::string_view> lines)
-{
-    for (auto line : lines)
-        co_await sink.write(line);
-}
-```
-
-What happens inside `co_await sink.write(line)`:
-
-1. Transform. `await_transform` delegates to `transform_awaitable`, which wraps the IoAwaitable in a `transform_awaiter`.<sup>[11]</sup>
-
-2. Connect. No work.
-
-3. Readiness. `await_ready()` returns `true`.
-
-4. Suspend. No work. The coroutine does not suspend.
-
-5. Launch. No work.
-
-6. Complete. No work.
-
-7. Extract. `await_resume()` returns.
-
-Three phases have work: transform, readiness, extract. The path incurs no suspension, no operation state construction, no receiver instantiation, no `variant` emplacement, and no scheduler affinity wrapping.
-
-`immediate` is the protocol's ceiling: `await_ready()` returns `true` because the fixture knows the result before `co_await` evaluates. The shipped libraries reach the same end by two paths. Corosio's socket awaitables return `true` from `await_ready()` only when a stop has been requested; `await_suspend` issues the syscall speculatively and, when it completes at once, returns the caller's own coroutine handle, so the coroutine suspends and resumes by symmetric transfer without a scheduler round-trip<sup>[15]</sup> (`native/native_tcp_socket.hpp`, `native/detail/reactor/reactor_stream_socket.hpp`). Capy's `any_write_stream` forwards the concrete awaitable's readiness through its function table<sup>[11]</sup> (`io/any_write_stream.hpp`, commit `9200ddc`): a ready stream takes the fixture's path through erasure, and a pending one suspends and resumes the same tail-call way; it issues no speculative syscall of its own. The fixture's `await_resume()` returns nothing; a shipped awaitable returns an `io_result` carrying an error code, which adds a return value and no phase. Corosio caps consecutive inline completions at an adaptive budget of 2 to 16, or 4 when no other thread has been woken to share the work, and posts the next completion through the queue, because unbounded inline completion starves other coroutines on the same executor. Inline completion is turned off entirely when the context is constructed from `io_context_options` at their defaults and the concurrency hint exceeds one. The budget is a cost of Corosio's shipped path that the fixture does not carry. On every path, no operation state, receiver, or `variant` exists; where a suspension occurs, the resumption is a tail call with no nested frame, and where the stream reports ready, Capy's erased path does not suspend at all.
-
-## 7. Comparison
-
-| Phase | Awaitable, fixture | Awaitable, shipped path | Sender |
-| --------- | ------------------ | ----------------------- | ------ |
-| Transform | `await_transform` wraps in `transform_awaiter` | same | `await_transform`, `as_awaitable`, `sender-awaitable` constructed |
-| Connect | none | none | `connect(sndr, awaitable-receiver)`: operation state and receiver |
-| Readiness | `await_ready()` is `true` | `await_ready()` is `false` on both: stop-based (Corosio) or forwarded from a pending stream (Capy) | `await_ready()` is `false`, unconditionally |
-| Suspend | none | suspend | suspend |
-| Launch | none | `await_suspend` issues the syscall speculatively (Corosio) or forwards through the function table (Capy) | `await_suspend` calls `start(state)` |
-| Complete | none | returns the caller's handle: symmetric transfer | `set_value`, `variant` emplace, `resume()` nested in `await_suspend` |
-| Extract | `await_resume()` | `await_resume()` | `await_resume()` reads the `variant` |
-
-Table 1. The seven phases of a single `co_await sink.write(line)` on a synchronous `string_sink`. The fixture column is the `immediate` awaitable of Section 6. The shipped-path column covers Corosio's speculative-syscall socket awaitable and Capy's erased `any_write_stream` over a pending stream; a ready stream takes the fixture column through erasure. The sender column is the `sender-awaitable` path of Section 5 as the working draft specifies it, whose exposition-only `await_suspend` returns `void` and so resumes nested; stdexec's shipped awaiters, generic and inline alike, return the handle instead (Section 11.1, Table 4). A cell reading "none" means the protocol has no work in that phase.
-
-| Property | Awaitable, fixture | Awaitable, shipped path | Sender |
-| ----------------------------- | ------------------ | ----------------------- | ------ |
-| Phases with work | 3 | 6 | 7 |
-| Coroutine suspensions | 0 | 1 | 1 |
-| Coroutine resumptions | 0 | 1, symmetric transfer | 1, nested inside `await_suspend` |
-| Operation state constructions | 0 | 0 | 1 |
-| Receiver instantiations | 0 | 0 | 1 |
-| `variant` emplacements | 0 | 0 | 1 |
-| Scheduler affinity wrappings | 0 | 0 | 0 |
-| Type erasure allocations per write | not erased | 0 (Capy `any_write_stream`; four function-table calls when ready, five when it suspends - Section 3) | 0-1 (`any_sender::connect`; its erased `connect`, `start`, and completion calls are not counted here) |
-
-Table 2. Objects and control transfers per write for the three paths of Table 1. Zero means the mechanism is not instantiated.
-
-The connect and complete phases are where the sender column constructs what the other two columns never do: an operation state, a receiver, and a `variant`. The shipped awaitable path shares the suspend and launch phases with the sender only when readiness cannot be answered before launch - Corosio's stop-based `await_ready`, or Capy's erased stream over a pending concrete stream - and it constructs nothing in them, completing by tail call where the sender's completion is nested. When the concrete stream reports ready, Capy's erased path takes the fixture column: Since commit `9200ddc` the wrapper forwards readiness and skips the suspension.
-
-## 8. Interoperation
-
-The awaitable protocol and the sender protocol are not mutually exclusive. An IoAwaitable can be wrapped as a sender and consumed by sender pipelines, and a sender can be consumed from coroutine-native code without `execution::task`.
-
-P4093R1<sup>[7]</sup> (awaitable-to-sender bridge) provides `as_sender`, which wraps any IoAwaitable as a `std::execution` sender:
-
-```cpp
-auto sndr = as_sender(sink.write(line))
-    | ex::then([] { /* next step */ });
-```
-
-The sender algebra works. `when_all` composes bridged IoAwaitables into parallel work. `let_value` sequences them. `upon_error` handles failures. The IoAwaitable is a leaf node in the sender's work graph. Structured concurrency is inherited from the sender pipeline.
-
-Without callback handles, the bridge allocates one coroutine frame per bridged operation - the frame exists only to produce a `coroutine_handle<>`, the only type the awaitable protocol accepts. P4126R1<sup>[9]</sup> (callback handles for zero-cost bridging) shows this allocation is eliminable. A callback handle - three pointers matching the coroutine frame prefix, zero heap allocation - gives senders a `coroutine_handle<>` without allocating a frame.
-
-The I/O layer is awaitable-native. Sender pipelines compose those awaitables into parallel work through the bridge. With P4126R1's callback handles,<sup>[9]</sup> the bridge imposes no allocation.
-
-## 9. Overhead by Consumer and I/O Shape
-
-Section 8 shows IoAwaitables entering sender pipelines via `as_sender`.<sup>[7]</sup> P4092R1<sup>[8]</sup> (sender-to-awaitable bridge) provides `await_sender`, through which senders are consumed from coroutine-native code without `execution::task`. P4088R1<sup>[6]</sup> (which documents the properties C++20 coroutines provide for stream I/O) examines the broader design fork between the two models.
-
-The question is which implementation shape minimizes total cost when both consumers - coroutines and sender pipelines - exist.
-
-| Consumer / I/O shape | Awaitable | Sender |
-| -------------------- | --------- | ------ |
-| **Coroutine** | | |
-| Synchronous | transform, readiness, and extract (Section 6) | all seven phases (Section 5) |
-| Asynchronous | no phase beyond the inherent suspend | connect and complete phases beyond the inherent suspend |
-| **Sender pipeline** | | |
-| Synchronous | none, given [P4126R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4126r1.pdf)<sup>[9]</sup> | none |
-| Asynchronous | none, given [P4126R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4126r1.pdf)<sup>[9]</sup> | none |
-
-Table 3. Protocol overhead per operation by consumer (coroutine or sender pipeline) and I/O shape (synchronous or asynchronous), for I/O primitives implemented as awaitables versus senders. The two awaitable-column pipeline cells assume the callback handles of P4126R1.
-
-The awaitable path imposes no phase beyond `[expr.await]`'s own in any cell. For synchronous I/O, the sender column carries the connect, suspend, launch, and complete phases of Section 5. For asynchronous I/O, the sender protocol adds `connect`, receiver wiring, and `variant` emplacement atop the inherent suspend; the asynchronous operation itself requires none of the three.
-
-For asynchronous I/O these added steps are a step count, not a separately observable runtime cost: Once the operation suspends to a scheduler, the suspension dominates and the steps are not measurable above it. The case under comparison is synchronous completion, where no suspension absorbs them.
-
-## 10. Composed I/O
-
-Composed I/O algorithms call lower-level operations in a loop. This section examines how the protocol cost from Sections 5-7 multiplies across layered I/O stacks - the dominant pattern in protocol implementations such as TLS, HTTP, WebSocket, SMTP, and DNS resolution.
-
-`read` fills a buffer by looping `read_some`. TLS decrypts by looping encrypted reads. HTTP sequences header parsing with body reads. Each layer is a coroutine composing awaitables. These algorithms are generic - constrained on concepts, agnostic to execution context.
-
-Under the sender protocol, each iteration of such a loop executes every phase of Section 5 independently - even when the operation completes synchronously. Each synchronous completion constructs an operation state, instantiates a receiver, suspends the coroutine, calls `start`, fires `set_value` on the receiver, emplaces the result into a `variant`, and resumes the coroutine. For a 64 KB read from a stream that hands back 4 KB per `read_some`, this is sixteen iterations. On a buffered stream where every completion is synchronous, that is sixteen operation states, sixteen receivers, sixteen suspensions, sixteen resumptions - for data already in user-space memory.
-
-The sender model's construction-before-launch separation is a strength during pipeline building: Aggregate state, let the optimizer see the full graph. Inside a composed I/O loop, the pipeline is already built and running. The connect phase that serves construction-time visibility persists into execution, where it is no longer needed.
-
-If the protocol can detect that the result is already available, the coroutine need not suspend. The suspension and resumption disappear. If the protocol can skip connection when the result is available, the operation state and the receiver disappear - the machinery that shuttles a value across a suspension boundary ceases to exist when no boundary exists. If the protocol expresses readiness through a single boolean - true: The value is here, take it directly; false: The value requires work, suspend, resume when ready - both cases are handled through one mechanism.
-
-This is `await_ready`.
-
-The following algorithm is `read` as implemented in Capy<sup>[11]</sup> (`include/boost/capy/read.hpp`). It composes `read_some` into `read` through `co_await`; the result is itself awaitable, and TLS composes `read`, and HTTP composes TLS:
-
-```cpp
-template <typename S, typename MB>
-  requires ReadStream<S> && MutableBufferSequence<MB>
-auto
-read(S& stream, MB buffers) ->
-        io_task<std::size_t>
-{
-    consuming_buffers consuming(buffers);
-    std::size_t const total_size = buffer_size(buffers);
-    std::size_t total_read = 0;
-
-    while(total_read < total_size)
-    {
-        auto [ec, n] = co_await stream.read_some(consuming.data());
-        consuming.consume(n);
-        total_read += n;
-        // A contingency that still completed the transfer is a success:
-        // report it only when the buffer was not filled.
-        if(ec && total_read < total_size)
-            co_return {ec, total_read};
+    bool await_suspend(std::coroutine_handle<> h) {
+        return stream.start_read(buffer, result, h);
     }
 
-    co_return {std::error_code(), total_read};
-}
-```
+    std::size_t await_resume() {
+        return result;
+    }
+};
 
-Composition nests without sender algebra. When `read_some` completes synchronously, no allocation occurs, no operation state is constructed, no receiver is wired; the protocol adds nothing to what the hardware delivers. The requirement surface at each `co_await` is three members: `await_ready`, `await_suspend`, `await_resume`. The protocol is conditionally lazy: `await_ready() == false` defers, `await_ready() == true` proceeds. The concept constraint defines the interface, the awaitable defines execution semantics, the coroutine body defines composition logic - three concerns, no coupling. The algorithm accepts any type satisfying `ReadStream`, works across execution contexts without recompilation or runtime overhead, and imposes minimal requirements on user types. The coroutine frame outlives every `co_await` within it; activations nest, destructors run on every exit path, cancellation propagates downward.
-
-When the stream is synchronous, no iteration leaves the coroutine's call chain: The fixture's `await_ready()` returns `true` - as does Capy's erased stream over a ready concrete stream - or, within Corosio's inline budget (Section 6), a shipped stream's `await_suspend` returns the caller's handle. On these paths no completion is scheduled and no operation state is constructed; the generic algorithm adds no protocol machinery to the copy.
-
-Stepanov's iterator concepts do not impose indirection when dereferencing a pointer. A `T*` satisfies `random_access_iterator` and dereferences in one instruction. The concept does not require constructing an intermediate state object, wiring a callback, or performing a two-phase access protocol - even though a disk-backed iterator requires all of those internally. The cost is proportional to what the underlying data access requires.
-
-The awaitable protocol has this property. `await_ready() == true` is the pointer dereference: The value is there, take it. `await_ready() == false` is the disk-backed iterator: The value requires work and the coroutine waits for it. The cost tracks the operation.
-
-## 11. Closing the Gap
-
-An already-available result is a case the committee has specified before. [P0159R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0159r0.html)<sup>[16]</sup> (2015), the draft Concurrency TS, specifies `make_ready_future`, a future whose shared state is ready at construction. The sender protocol specifies a construction-side counterpart, `just()`, a sender whose value is ready at construction - but no consumption-side one. Awaited from a coroutine, `just()` takes the full `sender-awaitable` path like any other sender; inside a running pipeline, where the construction-before-launch property that motivates the design has already been used, a synchronous completion still takes it.
-
-The sender model, as specified, does not match the awaitable model for synchronous I/O through the generic `sender-awaitable` path that every sender inherits unless it provides an escape. A concrete sender can sidestep that path by providing its own member `as_awaitable` or an await-completion adaptor<sup>[10]</sup> - manual, per-sender customizations that `any_sender` erases. The modifications below are what would lift the costs from the generic protocol itself, for every sender, including type-erased senders. Each addresses one layer of the gap.
-
-### 11.1. A Readiness Query
-
-`sender-awaitable::await_ready()` returns `false` unconditionally.<sup>[10]</sup><sup>[17]</sup> To skip suspension for senders that complete synchronously, a readiness query is required. The sender must advertise, at compile time or at run time, that its `start` will call `set_value` before returning.
-
-The `await_transform` of P3552R3<sup>[2]</sup> does bypass `affine_on` when the task's environment names `inline_scheduler` (Section 5, transform phase). It does not bypass the `sender-awaitable` path. The six phases that follow - connect, readiness, suspend, launch, complete, extract - execute regardless.
-
-| Mechanism | Where | What it provides | What it leaves |
-| --------- | ----- | ---------------- | -------------- |
-| `get_completion_behaviour` query | Proposed in P3206R0;<sup>[5]</sup> shipped as `get_completion_behavior` in stdexec<sup>[13]</sup> (`exec/completion_behavior.hpp`) | A sender advertises at compile time that it completes inline; stdexec's `task` answers the query | Not in the working draft; a query the working draft's `sender-awaitable::await_ready()` does not consult |
-| Inline `__sender_awaiter` | stdexec<sup>[13]</sup> (`__as_awaitable.hpp`) | For a sender the query marks inline, `connect` and `start` move into `await_suspend` and the operation state does not outlive it; both stdexec awaiters, generic and inline, return the continuation handle from `await_suspend`, so the resume is a symmetric transfer | `await_ready()` still returns `false`; the coroutine still suspends; the operation state and receiver are still constructed |
-| `get_await_completion_adaptor` | Working draft `[exec.get.await.adapt]`<sup>[10]</sup> | A sender's attributes supply an adaptor applied to it before `sender-awaitable` is built; the adapted sender may provide its own `as_awaitable`, reaching a custom awaitable without an `as_awaitable` member on the original sender | Per-sender, like the member, and lost under `any_sender` like the member; the generic `sender-awaitable` keeps its unconditional `false` |
-| `affine_on` member | P3941R2<sup>[3]</sup> s3.4; `affine()` in the working draft `[exec.affine]`<sup>[10]</sup> | A sender opts out of rescheduling | Affinity only (Section 11.4) |
-
-Table 4. Readiness and inline-completion mechanisms in the sender ecosystem, with what each closes of the gap traced in Sections 5-7 and what remains.
-
-stdexec is the closest of the four: Both of its awaiters avoid the nested resume, and the inline one additionally delivers the deferred connection of Section 11.3; it keeps the suspension, the operation state, and the receiver. None of the four gives `sender-awaitable` a readiness query; the working draft has none. What is required is a trait, a tag, or a constexpr query in the shape P3206R0 proposes, consulted by `sender-awaitable::await_ready()`.
-
-### 11.2. Conditional Suspension
-
-With a readiness query in place, `sender-awaitable::await_ready()` can return `true` when the sender advertises synchronous completion. The coroutine no longer suspends.
-
-But `connect` was already called in the `sender-awaitable` constructor.<sup>[10]</sup> The operation state was already materialized. The receiver was already wired. The `variant` was already allocated. The suspend phase was saved. The connect and complete phases were not.
-
-### 11.3. Deferred Connection
-
-To skip those steps, `connect` must be moved from the `sender-awaitable` constructor into `await_suspend`, where it can be bypassed when `await_ready()` returns `true`.
-
-But the value needs to come from somewhere. `await_resume` must return the result. If `connect` and `start` did not execute, no receiver received the value. The sender needs a second value-delivery mechanism - a `get_value()` member, a direct extraction path, a way to produce the result without constructing an operation state, wiring a receiver, calling `start`, routing through `set_value`, and emplacing into a `variant`.
-
-The sender model then carries two value-delivery mechanisms: channels for asynchronous completion, direct extraction for synchronous completion.
-
-### 11.4. Affinity Wrapping Is Already Conditional
-
-Scheduler affinity is not part of the gap. `[task.promise]` (P3552R3 p10, working draft p6) skips the affinity wrapper for every sender when the task's environment names `inline_scheduler`,<sup>[2]</sup> and P3941R2<sup>[3]</sup> lets an individual sender opt out of rescheduling through an `affine_on` member function. Neither mechanism reaches the `sender-awaitable` path of Sections 11.1-11.3: with affinity wrapping removed, `await_ready()` still returns `false`, the coroutine still suspends, and the operation state is still constructed. The remaining modifications concern that path alone.
-
-### 11.5. Zero-Allocation Type Erasure
-
-`any_sender::connect` produces a type-erased operation state whose size is unknown at compile time. The current implementations use small-buffer optimization (64 bytes in stdexec) or heap allocation.<sup>[13]</sup> The per-operation cost is zero or one allocation.
-
-Measured in the Capy benchmark suite<sup>[11]</sup> (`bench/beman`, commit `d45ae3e`) on a type-erased no-op read, single thread, 20,000,000 operations per cell, clang 22.1.5 release build: The type-erased awaitable consumed by a `capy::task` coroutine allocates zero times per operation; the type-erased `any_sender` consumed by a `beman::execution::task` coroutine allocates once. Wall-clock was 37 ns per operation for the awaitable and 55 ns for the sender on a machine that was not recorded; a rerun of the same source on 2026-08-28 with clang 22.1.8 on an Intel Core i9-13900H gave 36.2 ns and 54.7 ns with the same allocation counts. The wall-clock figure spans two coroutine frameworks and is reported for context; the allocation count is the structural result.
-
-The awaitable model's type erasure adds no allocation on either path, at the call counts of Section 3. To match this, the sender needs a base class with a virtual function that returns the value directly - without constructing an operation state, without wiring a receiver, without calling `start`.
-
-### 11.6. The Result
-
-The preceding sections trace the modifications the sender model would require to match the awaitable model for synchronous I/O. The following hypothetical type collects them:
-
-```cpp
-struct sync_ready_sender
-{
-    using sender_concept = sender_t;
-    using completion_signatures =
-        completion_signatures<set_value_t()>;
-
-    // 11.1: readiness query
-    static constexpr            // cf. await_ready()
-        bool is_synchronous = true;
-
-    // 11.3: direct extraction (bypass connect)
-    void get_value()            // cf. await_resume()
-        const noexcept;
-
-    // 11.5: virtual base for type erasure
-    virtual void                // cf. virtual
-        get_value_erased()      //     await_resume()
-        const;
-
-    // original protocol (retained for async)
+struct buffered_read_sender {
     template<class Receiver>
-    struct state { /* ... */ };
-
-    template<class Receiver>
-    state<Receiver> connect(Receiver&&) const;
+    operation_state<Receiver> connect(Receiver);
+    // operation_state::start first checks the same user-space buffer,
+    // then calls set_value or starts the pending receive.
 };
 ```
 
-The awaitable that already provides the same capabilities:
+This is illustrative code rather than wording or a production implementation. It assumes the stream controls access to its user-space buffer so the readiness decision remains valid through extraction.
 
-```cpp
-struct immediate
-{
-    bool await_ready() const noexcept;
-    void await_suspend(
-        std::coroutine_handle<>,
-        io_env const*) noexcept;
-    void await_resume() noexcept;
-};
-```
+Both projections support ready and pending instances. The awaiter exposes the decision to `[expr.await]`; its cache-hit object proceeds directly to `await_resume`. The sender exposes the decision through the timing of receiver completion after `start`. When that sender reaches the generic bridge, `await_ready` remains false for both objects.
 
-Each modification in the sender column has a direct counterpart in the awaitable's three members. The sender protocol arrives at a readiness query (`is_synchronous` maps to `await_ready`), a direct extraction path (`get_value` maps to `await_resume`), and virtual dispatch for type erasure (maps to the function-table call of Section 3).
+The three cases differ in when the result becomes available. A result produced before construction is an eager fixture, immediate system-call completion is discovered during initiation, and a user-space buffered result supports a genuine per-instance pre-start decision.
 
-## 12. Concerns
+## Existing Alternatives Are Available but Non-Universal
 
-**"P4126R1 is unshipped. The bridge cost is hypothetical."** Both sender-pipeline cells in the awaitable column of Section 9 depend on P4126R1.<sup>[9]</sup> Callback handles would allow sender pipelines to consume awaitables without allocation. The core finding (Sections 5-7) rests on normative text; the bridge zeros are what callback handles would add.
+The generic fallback is not the only coroutine path available to a sender. Current wording and published proposals provide multiple ways to select a different awaiter or describe completion behavior.
 
-**"A sender can provide a member `as_awaitable` and skip the `sender-awaitable` phases. No protocol change is needed."** True. `[exec.as.awaitable]` p7 uses a sender's own `as_awaitable` when the sender provides one, and otherwise an awaitable produced by the environment's await-completion adaptor when that is well-formed, before it falls back to constructing the generic `sender-awaitable`. The following is a paraphrase of p7 that omits the two awaiter-passthrough branches:<sup>[10]</sup>
+### A member can return a ready awaiter
 
-```cpp
-// paraphrase of [exec.as.awaitable] p7; adapt is adapt-for-await-completion
-template<class Expr, class Promise>
-decltype(auto) as_awaitable(Expr&& e, Promise& p)
-{
-    if constexpr (requires { e.as_awaitable(p); })
-        return e.as_awaitable(p);                        // (7.1) the sender's own
-    else if constexpr (requires {
-        adapt(transform_sender(e, get_env(p))).as_awaitable(p); })
-        return adapt(transform_sender(e, get_env(p)))
-            .as_awaitable(p);                            // (7.2) the adaptor's
-    else
-        return sender-awaitable{
-            adapt(transform_sender(e, get_env(p))), p};  // (7.4) every phase
-}
-```
+The highest-priority `as_awaitable` branch invokes the expression's own member.<sup>[1]</sup> A `buffered_read_sender` can use that member to return the awaiter above. On a cache hit, no generic connection, receiver, operation state, or result variant is constructed for coroutine consumption.
 
-In `execution::task` with an `inline_scheduler` environment (Section 5), `await_transform` passes the sender to `as_awaitable` unwrapped, and a sender whose `as_awaitable` returns a synchronous awaitable then takes the path of Section 6.<sup>[2]</sup> `connect`, the receiver, `start`, and the `variant` are never instantiated. Only the transform, readiness, and extract phases remain. Under the default environment the sender is first wrapped in `affine_on`, and the member check in `[exec.as.awaitable]` runs on the wrapper rather than on the sender that defines the member.
+The sender exposes both interfaces explicitly. Sender consumers use `connect` and `start`; coroutine consumers use the awaiter returned by `as_awaitable`. The two projections must agree on values, errors, stopped behavior, cancellation, environment, affinity, lifetime, and concurrency.
 
-The affinity bypass and the `as_awaitable` member are independent mechanisms: The first is a property of the task's environment and applies to every awaited sender, the second is per-sender. Only the second reaches `sender-awaitable`, and it is lost under type erasure.
+### Await-completion adaptation is preserved by ordinary unary composition
 
-The synchronous fast path the sender reaches through `as_awaitable` is an awaitable: The sender hands one back, and the awaitable does the work. Closing the gap for one concrete sender, awaited from a coroutine, is one existing customization point returning the three-member struct of Section 6.
+P3570R2 identified that a raw member on a leaf is unavailable after a sender adaptor changes the expression's type.<sup>[6]</sup> The working draft's response is `get_await_completion_adaptor`, a forwarding attribute query applied after domain transformation.<sup>[1]</sup> Standard unary parent senders forward forwarding attributes by default, so an await-completion adaptor can receive the transformed pipeline rather than only the original leaf.
 
-Two costs remain. The `as_awaitable` member is manual and per-sender; a sender that omits it inherits every phase of Section 5. And it is lost under type erasure: `any_sender` erases the concrete sender and the member with it, and `any_sender::connect` materializes the operation state of Section 11.5. Type erasure is the one sender-specific cost no `as_awaitable` member reaches.
+A claim that every `then` necessarily discards await customization is no longer correct. Multi-child parents have empty attributes by default, behavior-changing adaptors may need a different policy, and user-defined wrappers preserve forwarding attributes only when their `get_env` participates in the convention.
 
-The scope is the coroutine consumer. A sender pipeline never enters `as_awaitable`; Section 9 records no protocol phase for either synchronous pipeline cell.
+### Domains can transform the whole expression
 
-**"The protocol cannot know at compile time whether a given co_await will always complete synchronously. The operation state must be constructed because the protocol must handle the general case."** The awaitable protocol handles this case at runtime. `await_ready()` is evaluated at the point of `co_await`: If the result is available, return `true` - no suspension; if work is required, return `false` - suspend. The protocol does not need compile-time knowledge. It asks the operation at the point of evaluation. For senders that are always synchronous (like `inline-sender`), the property is known at compile time - a constexpr trait could express it. The working draft has no such trait; P3206R0<sup>[5]</sup> proposes one and stdexec ships it, and neither is consulted by the working draft's `sender-awaitable::await_ready()` (Section 11.1, Table 4). The "cannot know" argument applies equally to awaitables, yet an awaitable whose `await_ready()` depends on runtime state handles both cases through the same three-member protocol: when ready, no suspension, no operation state, no receiver; when not ready, a suspension until the work completes. One protocol, two behaviors, selected at the point of evaluation.
+`transform_sender` gives completion and start domains the complete sender expression and recursively transforms the result when its type changes.<sup>[1]</sup> An I/O domain can therefore recognize a family of sender expressions and supply a common coroutine representation. This is broader than adding one member to each leaf type.
 
-**"The optimizer eliminates the protocol overhead."** The nested resumption is observable at runtime as stack growth, independent of optimization. When `await_ready()` returns `false`, `await_suspend` calls `start`; for an inline completion, `set_value` calls `resume()` on the coroutine handle from inside `await_suspend`, so the coroutine resumes nested on the same stack, before `await_suspend` returns. That nested resumption is the stack-growth hazard P2583R4<sup>[17]</sup> documents, and it occurs whether or not the optimizer inlines `connect` and `start`. `[exec.as.awaitable]` specifies unconditional suspension for `sender-awaitable`;<sup>[10]</sup> the as-if rule would let an implementation elide it only where nothing observable depends on it, and the one shipped implementation Table 4 surveys, stdexec, does not. Making the skip part of the protocol requires a specification change, which is Section 11.1.
+A transformation that recognizes `then`, `let_value`, or a multi-child operation must preserve the expression's value, error, stopped, environment, cancellation, affinity, and lifetime semantics. The domain centralizes that work without removing it.
 
-**"Operation state construction delivers structured concurrency guarantees."** Genuine for asynchronous operations where the coroutine suspends and work executes concurrently. For a synchronous write where the data is in the string before `co_await` evaluates, there is no concurrent lifetime to manage. The operation state guarantees a property that was never at risk.
+### Completion behavior can be static or dynamic
 
-**"Protocol step counts are not runtime costs."** True for `connect`, `start`, and `set_value` when sender and receiver are fully visible to the optimizer and the optimizer is sufficiently aggressive. Not true for the resumption, which under the working draft's `sender-awaitable` is a nested call inside `await_suspend` regardless of inlining; stdexec's awaiters return the handle instead (Table 4), the shipped awaitable paths resume by symmetric transfer when they suspend, and the fixture and a ready erased stream do not suspend at all. Not true across type-erasure boundaries, where `any_sender::connect` materializes an operation state outside the optimizer's view.
+P3206R0 proposes a sender attribute describing inline, synchronous, asynchronous, or unknown completion.<sup>[5]</sup> The proposal gives standard adaptors explicit combination rules and gives `split` a dynamic result after its shared operation has completed. It therefore demonstrates that an optional runtime attribute does not require a new member on every sender type.
 
-**"Awaitables do not compose into work graphs."** They do, through the bridge. Section 8 shows IoAwaitables consumed by sender pipelines via `as_sender`.<sup>[7]</sup> The sender algebra - `when_all`, `let_value`, `upon_error` - works. The bridge cost is eliminable with P4126R1.<sup>[9]</sup>
+Completion behavior alone does not produce a result. A consumer can use it to select state lifetime, synchronization, trampoline, or coroutine-transfer strategies. A true pre-start fast path still needs an awaiter or another rule that initiates the sender and stores its completion before `[expr.await]` proceeds to `await_resume`.
 
-**"Unconditional suspension is the sound default."** The awaitable protocol solved this in C++20 with a single boolean. `await_ready()` provides the override. The sender protocol has no equivalent conditional path.
+### Already-awaitable senders need no bridge
 
-**"The composed algorithm is sequential - real composition requires parallelism."** Sequential composition over a single stream is expressed as a coroutine loop. Parallel composition across multiple streams - scatter-gather, concurrent requests, fan-out/fan-in - is expressed through the sender algebra via the bridge of Section 8. Sequential I/O composition is the pattern Section 10 names. Each layer is a coroutine composing awaitables, and each inner await that completes synchronously executes the connect, suspend, launch, and complete phases independently under the sender protocol. The multiplier is proportional to the protocol's depth: HTTP over TLS over TCP is three layers of composed coroutines, each with its own `read_some` loop, each iteration incurring the cost independently.
+The sender concepts recognize qualifying awaitables as senders, and `as_awaitable` returns an expression that is already an awaiter before selecting `sender-awaitable`.<sup>[1]</sup> One type can therefore participate in both sets of concepts without passing through the generic fallback.
 
-**"The composed read loop has no cancellation propagation."** Stop tokens propagate transparently through `io_env` - the execution environment bundle passed to every IoAwaitable via `await_suspend(coroutine_handle<>, io_env const*)`.<sup>[1]</sup> Each child operation inherits the caller's stop token without explicit wiring. Every stream operation observes the stop token and may complete early with an operation-cancelled error. The mechanism is defined in P4003R3<sup>[1]</sup>.
+Existing customization paths can avoid the generic bridge, preserve await adaptation through ordinary unary composition, or specialize a whole domain. No current working-draft rule makes branch 7.4 itself inspect per-instance readiness.
 
-**"The bridge concedes the dependency."** The bridge operates in both directions. P4093R1<sup>[7]</sup> bridges IoAwaitables into sender pipelines. P4092R1<sup>[8]</sup> bridges senders into coroutine-native code without `execution::task`. Section 9 shows the cost is asymmetric: If I/O is an awaitable, neither consumer incurs protocol overhead; if I/O is a sender, coroutine consumers incur it.
+## Capability Preservation Under Composition and Erasure
 
-**"The comparison measures the wrong case."** Synchronous completion is not a corner case in I/O. Buffered writes, cached reads, DNS cache hits, and in-memory operations complete synchronously. A protocol that adds cost to the common fast path repeats that cost on every operation on a connection.
+An optional capability matters only where the surrounding abstraction preserves it. Sender attributes, domain transformation, and configurable erased interfaces provide preservation mechanisms, but each boundary has a different rule.
 
-**"Senders retarget via scheduler swap; awaitables require recompilation."** Section 3 demonstrates retargeting by relinking: The linker swaps the object file behind the function table.
+### Composition needs semantic combination
 
-**"The modifications in Section 11 are natural evolution."** Each modification introduces a new mechanism: a readiness query, a second value-delivery path, virtual dispatch for type erasure. The awaitable protocol provides the same capability with three members.
+A standard parent with one child forwards attributes whose queries opt into forwarding.<sup>[1]</sup> This rule preserves `get_await_completion_adaptor` across ordinary unary adaptors. A parent with multiple children has empty attributes by default, because selecting one child's await policy would not describe the combined operation.
 
-**"The type erasure comparison is asymmetric."** Both paths use type erasure at the same boundary. The awaitable path makes four function-table calls when the stream reports ready, five with a symmetric-transfer resume when it suspends, and constructs no operation state; `any_sender` makes its own erased calls to `connect`, `start`, and the completion, and materializes an operation state the compiler cannot see through, in a small buffer or on the heap. The count that separates the two is the allocation, and Section 11.5 measures it.
+P3206R0 specifies that `then` preserves predecessor behavior, `when_all` combines every child conservatively, `let_value` considers every sender the function may return, and `split` can change its answer after shared completion.<sup>[5]</sup> These are semantic rules, not mechanical forwarding.
 
-**"The falsification criteria measure senders on the awaitable's own terms."** The Disclosure names the limitation: Coroutine-native I/O cannot express compile-time work graphs. Section 4 credits senders with three properties awaitables do not match, and Section 9 covers both synchronous and asynchronous I/O. The criteria in Section 13 cover synchronous protocol cost, which is the claim under test.
+User-defined adaptors follow the same preservation rule. A wrapper that follows the standard unary-parent attribute convention preserves forwarding queries. Adding an optional query does not give an existing wrapper with unrelated `get_env` behavior that preservation. Nonparticipating senders remain valid and use the fallback, so the compatibility effect is partial optimization coverage rather than source breakage.
 
-## 13. Falsification
+### Erasure preserves a declared interface
 
-The observations documented in this paper would no longer hold if any of the following were demonstrated:
+A closed erased interface preserves the operations and queries it declares. Current stdexec parameterizes `any_sender` with a list of erased sender queries; the default list is empty.<sup>[21]</sup> An erased wrapper can include a completion-behavior query with a fixed signature. It does not automatically reproduce an arbitrary promise-dependent `as_awaitable` member from the hidden sender.
 
-- A sender protocol mechanism, equivalent to `await_ready`, that skips `connect` and `start` for trivially ready senders without introducing a second value-delivery path.
+A fixed I/O eraser can expose its own outer `as_awaitable`. Capy's public benchmark code contains an erased read sender with both `connect` and `as_awaitable`, while its erased awaitable stream reserves concrete awaiter storage and forwards `await_ready` through a function table.<sup>[22]</sup> These examples establish that erasure itself does not erase readiness when readiness is part of the declared interface.
 
-- A `sender-awaitable` implementation in which `await_ready()` returns `true` when the sender is known to complete synchronously, without requiring `connect` to have already executed. stdexec's inline awaiter (Table 4) defers `connect` and keeps `await_ready()` at `false`, so it does not meet this criterion.
+The fixed stream and a general erased sender solve different storage problems. A fixed stream is defined for one operation family and one result shape, with a storage policy fixed at wrapper construction. A general erased sender accepts compatible sender expressions whose receiver-dependent operation states may have different sizes and alignments.
 
-- A type-erasure mechanism for senders that achieves zero allocations per operation without constructing an operation state and without reintroducing virtual dispatch.
+### Operation state and allocation are independent
 
-## 14. Conclusion
+An operation state can be constructed in caller storage, in a coroutine frame, in an inline erasure buffer, in preallocated storage, or in storage acquired for that operation. Current stdexec requests an inline buffer for its erased operation state and allocates only when the concrete model does not fit its small-buffer criteria.<sup>[21]</sup> Constructing an operation state therefore does not imply allocating it.
 
-For a result already in memory, the sender protocol connects, suspends, launches, completes through a receiver, and resumes nested. The awaitable fixture checks readiness and returns, and the shipped libraries avoid the sender's construction on this path: Capy's erased stream forwards readiness and skips the suspension when the stream reports ready, and Corosio, whose `await_ready` answers only a stop request, suspends and resumes by tail call, at the cost of an inline budget. The gap is in the generic `sender-awaitable` path: `await_ready()` is specified as `false`, `connect` runs in the constructor, and the receiver's `set_value` resumes the coroutine from inside `await_suspend`. Sections 11.1, 11.3, and 11.5 name what would close it - a readiness query consulted before suspension, an extraction path that does not pass through a receiver, and an erased base that returns the value through one virtual call - and each is the sender-side spelling of `await_ready`, `await_resume`, and the function-table call of Section 3.
+An interface containing only sender connection and selected attributes cannot provide an awaiter projection that it omits. Semantic alignment is required when an interface contains both projections.
 
-The per-operation difference is multiplied by composition. Section 10 shows a `read` that loops `read_some` and completes synchronously on every iteration; under the sender protocol each of those iterations constructs and tears down an operation state, and TLS and HTTP each add a loop of their own above it.
+Attribute forwarding preserves compatible queries through ordinary unary boundaries, while behavior-changing composition and closed erasure require explicit semantics.
 
-The two protocols interoperate. IoAwaitables enter sender pipelines through `as_sender`;<sup>[7]</sup> senders enter coroutine-native code through `await_sender`.<sup>[8]</sup> P4126R1's callback handles<sup>[9]</sup> eliminate the bridge's allocation cost. If I/O primitives are awaitables, neither coroutine consumers nor sender-pipeline consumers incur protocol overhead. If I/O primitives are senders, coroutine consumers incur it.
+## Implementations Optimize Inline Completion Without Adding Readiness
 
-The wording that would change this is `[exec.as.awaitable]` and `[task.promise]` in the working draft,<sup>[10]</sup> which came from P2300R10<sup>[12]</sup> and from P3552R3<sup>[2]</sup> with P3941R2;<sup>[3]</sup> a change there is a paper against those sections, reviewed by LEWG. Until the wording changes, a sender awaited from a coroutine carries a suspension and an operation state for a result that is already in memory.
+Two public implementations show that false readiness does not determine generated cost. Their source structures retain sender connection and receiver completion while changing state lifetime and coroutine transfer.
+
+### stdexec selects a statically inline awaiter
+
+At NVIDIA/stdexec commit `2c56ffe7`, both the generic and statically inline sender awaiters return `false` from `await_ready()`.<sup>[21]</sup>
+
+| Source property | Generic stdexec awaiter | Statically inline stdexec awaiter |
+| --- | --- | --- |
+| Selection | Completion behavior is not statically inline for every possible channel | Every possible channel is absent or reports inline completion |
+| Stored before `await_suspend` | Connected operation state and thread-ID handshake | Sender |
+| `connect` | Awaiter constructor | Local to `await_suspend` |
+| `start` | `await_suspend` | `await_suspend` |
+| Coordination | Atomic thread-ID exchange and cross-thread defense | No atomic handshake member |
+| Transfer from `await_suspend` | Continuation or `noop_coroutine` | Selected continuation |
+
+Table 3. The source-level differences between stdexec's generic and statically inline sender awaiters at commit `2c56ffe7`. The table describes code structure rather than optimizer output or latency.
+
+The specialized path relies on completion behavior that establishes that the local operation state cannot outlive `await_suspend`. It then connects, starts, and returns the continuation. This removes the generic handshake without making readiness true, skipping the operation state, or bypassing receiver completion.
+
+stdexec's deployed completion behavior is compile-time and per completion channel.<sup>[21]</sup> A missing query produces `unknown`; `just`, `just_error`, and `just_stopped` publish inline behavior. This implementation is narrower than P3206R0's dynamic `split` result.<sup>[5]</sup>
+
+### Beman.Execution uses one guarded path
+
+At Beman.Execution commit `a20a6f63`, `sender_awaitable` connects in its constructor, reports false readiness, starts in `await_suspend`, and coordinates completion with an atomic Boolean.<sup>[23]</sup> Inline completion causes `await_suspend` to return the continuation; pending completion returns `noop_coroutine` and later resumes the continuation.
+
+Beman's `inline_scheduler` calls `set_value` directly from `start`, but its attributes do not report completion behavior at that revision.<sup>[23]</sup> On 2026-09-07, a complete snapshot at commit `a20a6f63` was scanned case-insensitively for `completion_behavior`, `completion behavior`, `completes_inline`, `any_sender`, and `any_receiver`; no match occurred. This search establishes exact token absence in that revision, not semantic absence under every possible name. The inline sender uses the same guarded awaiter.
+
+### Source structure is not a performance measurement
+
+The source establishes where connection and start occur, which state is stored, which abstract-machine atomics are present, and which coroutine handle is returned. It does not establish instruction counts, latency, cache effects, devirtualization, or whether a particular erased operation allocates.
+
+Both implementations also avoid the working draft's direct nested `.resume()` for completion discovered during `start`. They return a continuation handle from `await_suspend`, providing symmetric transfer at the coroutine boundary. The protocol operation is symmetric transfer; a compiler may implement it as a tail transfer.
+
+stdexec demonstrates a lower-state path for statically inline completion without demonstrating per-instance pre-start readiness in the generic fallback.
+
+## Objections Define the Scope
+
+The objections below separate sender execution from pre-start readiness, identify repairs the finding permits, and exclude consumers that never enter the coroutine bridge.
+
+### "Senders already support synchronous I/O"
+
+The working draft permits completion during `start`, `inline_scheduler` completes that way, and P2300R10's `recv_sender` handles immediate and pending `WSARecv` outcomes in one sender type.<sup>[1]</sup><sup>[3]</sup> Those mechanisms expose completion timing through a receiver. They do not give branch 7.4 a different answer to `await_ready`.
+
+### "Immediate I/O completion is normally discovered only after initiation"
+
+Immediate completion of overlapped `WSARecv` becomes known only during initiation.<sup>[18]</sup> An awaiter for that operation initiates from `await_suspend`, while a sender initiates from `start`. The pre-start advantage applies to higher-level user-space buffering and cached results, not to every operation that might complete immediately.
+
+### "The generic bridge can be repaired without changing the sender concept"
+
+stdexec's specialized awaiter moves connection into `await_suspend`, avoids the generic atomic handshake, and returns a continuation handle.<sup>[21]</sup> A working-draft change could adopt that structure without changing the base sender concept.
+
+Such a repair addresses state lifetime, coordination, and transfer after false readiness. It does not add a query to the generic bridge for whether this sender object already contains a result. The distinction is semantic rather than a claim that the current bridge cannot improve.
+
+### "P3206R0 can return runtime completion behavior"<sup>[5]</sup>
+
+P3206R0 gives `split` a dynamic answer after shared completion and proposes combination rules for standard adaptors.<sup>[5]</sup> An optional query would leave existing senders valid and could provide incremental optimization wherever preserved.
+
+P3206R0 describes when receiver completion occurs relative to `start`; it does not specify how a coroutine obtains a value when connection and receiver completion are skipped.<sup>[5]</sup> The proposed query is also absent from the current generic bridge. A future bridge could initiate from `await_ready` or select another awaiter, but that design would add wording beyond the adopted path.
+
+### "Forwarding queries and domains avoid per-sender customization"
+
+The await-completion adaptor query forwards through ordinary unary standard adaptors, and a domain can transform a complete expression before awaiter selection.<sup>[1]</sup><sup>[6]</sup> These facilities refute a claim that every concrete sender needs its own member.
+
+Behavior-changing adaptors still need semantics for the transformed expression, multi-child parents need a combination policy, and closed erasure needs an interface entry. Centralizing the policy in a domain reduces duplication while retaining the translation boundary.
+
+### "Every co_await operand becomes an awaiter"
+
+Producing an awaiter is the required translation target, so the presence of an awaiter does not establish which native protocol an I/O API ought to expose. The relevant difference is whether the leaf already implements the language-facing readiness and extraction operations or reaches them after sender transformation, adaptation, connection, and receiver completion.
+
+### "One operation can expose both sender and awaitable projections"
+
+The member `as_awaitable` path, qualifying awaitables recognized as senders, and fixed dual-protocol erasure all support this design.<sup>[1]</sup><sup>[22]</sup> A dual projection can serve sender pipelines and coroutine consumers from one underlying operation implementation.
+
+The design has a larger contract than either projection alone. Values, errors, cancellation, stopped behavior, affinity, environment, lifetime, and concurrency must remain equivalent across both public paths.
+
+### "Protocol steps do not establish runtime overhead"
+
+The stdexec specialization retains false readiness, connection, an operation state, `start`, receiver completion, and extraction while removing a synchronization protocol from its source.<sup>[21]</sup> Runtime claims require controlled measurements and generated-code inspection for the implementation and erasure boundary being discussed.
+
+The normative evidence establishes wording requirements and observable control-flow rules; it does not establish runtime cost.
+
+### "Pending operations need state in either model"
+
+A pending `WSARecv` needs stable buffers, overlapped state, cancellation state, and a continuation.<sup>[18]</sup> A sender places those objects in an operation state; an awaiter can place equivalent objects in the coroutine frame or another stable owner. Neither model has a state advantage once the operation remains pending.
+
+### "Skipping every suspension can harm fairness"
+
+A long chain of ready operations can delay other work. An executor or I/O context may impose an inline-completion budget or scheduling boundary. That policy is independent of whether the leaf protocol can observe readiness; a ready path makes the decision available to the execution policy.
+
+### "Sender-native consumers never pay for sender-to-awaitable translation"
+
+A sender pipeline, direct receiver, scope, or `sync_wait` consumer never enters `as_awaitable`. Conversely, an awaitable leaf crossing into a sender pipeline needs an awaitable-to-sender bridge, and published bridge designs have their own continuation and storage requirements.<sup>[15]</sup><sup>[16]</sup>
+
+Only coroutine-centric I/O leaves are covered. Sender-native work graphs are outside the comparison, and no leaf protocol is claimed to minimize every consumer's cost.
+
+The objections narrow the comparison to coroutine-centric I/O with results available before initiation. Sender-native consumers and completion discovered only during initiation remain outside that boundary.
+
+## Conclusion
+
+Buffered I/O needs an object-specific decision before suspension. The awaiter interface exposes that decision through readiness, conditional initiation, and extraction. A sender-valued leaf first presents a graph-construction protocol, which `execution::task` translates before the language can consume it.
+
+The sender model's graph, completion, ownership, environment, domain, and concurrency facilities remain available to sender-native consumers. At a coroutine leaf, the generic bridge reports false readiness for every instance.
+
+The current wording provides concrete alternatives to the generic fallback. A member, forwarding await-completion adaptor, or domain transformation can supply another awaiter; P3206R0 sketches static and dynamic completion behavior;<sup>[5]</sup> a fixed erased interface can retain either facility when it declares it. Those mechanisms correct claims that customization is always per-leaf, that optional attributes are ineffective, or that erasure necessarily loses readiness. Behavior-changing composition needs combination rules, closed erasure needs an interface entry, and dual projections need one semantic contract.
+
+Implementations can improve the false-ready path without adding readiness. stdexec moves connection and start into `await_suspend` for statically inline senders, removes its generic handshake, and returns the continuation.<sup>[21]</sup> Beman uses one guarded path.<sup>[23]</sup> These structures demonstrate that named protocol steps do not determine runtime cost.
+
+On the stated criteria, direct implementation of the language-facing awaiter makes awaitables the natural leaf protocol for coroutine-centric I/O. A sender-valued interface introduces a second composition model before reaching the same language boundary, while its generic translation omits the object-specific pre-start decision. Sender pipelines can consume awaitable leaves through an explicit bridge when static graphs or sender-native concurrency are required. Designers of future networking libraries, task implementations, domains, and erased wrappers can use the boundary documented here to choose the primary protocol and its adapter.
 
 ## Disclosure
 
 The author provides information and serves at the pleasure of the committee.
 
-The author developed and maintains [Capy](https://github.com/cppalliance/capy)<sup>[11]</sup> and [Corosio](https://github.com/cppalliance/corosio)<sup>[15]</sup>, coroutine-native I/O libraries under the C++ Alliance.
+The author developed and maintains [Capy](https://github.com/cppalliance/capy)<sup>[22]</sup> and [Corosio](https://github.com/cppalliance/corosio)<sup>[24]</sup>, coroutine-native I/O libraries under the C++ Alliance.
 
-This paper documents the protocol-level cost difference between awaitables and senders when I/O operations complete synchronously.
+The paper records a finding about the protocol boundary used when coroutine-centric I/O returns sender-valued operations.
 
-Capy and Corosio implement I/O using the coroutine-native model. They compete with sender-based networking frameworks. The author advocates for the coroutine-native model. The sender model is the competing paradigm examined in this paper. The author has a stake in the coroutine model's adoption.
+Capy and Corosio use awaitable-native I/O. The author advocates the awaitable-native model and has a professional interest in its adoption.
 
-The write-side readiness forwarding described in Sections 3 and 6 is recent: Capy commit `9200ddc` (August 2026), applied during the drafting of this paper, aligned `any_write_stream` with the immediate-completion behavior its documentation and the read-side wrapper already specified. The core finding does not rest on that path; the fixture and the normative sender text carry it.
+The comparison does not measure a complete networking framework. It does not rank sender-native consumers, and it presents no benchmark result. Awaitable leaves also require an adapter when consumed by a sender pipeline.
 
-Coroutine-native I/O cannot express compile-time work graphs. This is a genuine limitation.
+This paper belongs to the Network Endeavor series. Companion papers include P4003R3 on IoAwaitable,<sup>[13]</sup> P4092R1 and P4093R1 on both bridge directions,<sup>[14]</sup><sup>[15]</sup> P4126R1 on callback handles,<sup>[16]</sup> and P2583R4 on symmetric transfer through sender composition.<sup>[11]</sup>
 
-This paper belongs to the Network Endeavor series. Companion papers in the series include P4003R3<sup>[1]</sup> (the IoAwaitable protocol), P4088R1<sup>[6]</sup> (coroutine advantages for stream I/O), P4093R1<sup>[7]</sup> (awaitable-to-sender bridge), P4092R1<sup>[8]</sup> (sender-to-awaitable bridge), P4126R1<sup>[9]</sup> (callback handles for zero-cost bridging), and P2583R4<sup>[17]</sup> (symmetric transfer in sender pipelines).
+The method compares public working-draft wording, published WG21 papers, official operating-system documentation, and source pinned to immutable public repository commits. No benchmark result is used.
 
-This paper was drafted and revised with machine assistance (Claude), under the author's direction; the technical claims were verified against the cited sources and repositories.
+The paper was drafted and revised with machine assistance under the author's direction. Every quotation and technical claim is subject to verification against the cited public source.
 
 This paper asks for nothing.
 
 ## Acknowledgments
 
-Eric Niebler, Kirk Shoop, Lewis Baker, and their collaborators for `std::execution` and the sender algebra. Dietmar K&uuml;hl and Maikel Nadolski for [P3552R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3552r3.html)<sup>[2]</sup> (`std::execution::task`). Dietmar K&uuml;hl for reviewing an earlier draft and remarking that the sender example was wrong. Investigating that remark led to a closer reading of P3552R3's `await_transform` and of the environment-level affinity bypass in `[task.promise]` (p10 in P3552R3, p6 in the working draft), which informed the task configuration used in Section 5. Robert Leahy for the AIO-to-sender bridge.
+Eric Niebler, Lewis Baker, Kirk Shoop, and the P2300R10 authors specified the sender model and published the Windows receive example used to distinguish completion during initiation. Dietmar K&uuml;hl and Maikel Nadolski specified `execution::task` and its scheduler-affinity integration. Fabio Fracassi documented the composition problem that motivated the await-completion adaptor. Dalton M. Woodard and Maikel Nadolski developed the public completion-timing classifications examined here. Mungo Gill, Steve Gerbino, and Klemens Morgenstern developed the companion coroutine and bridge analyses.
 
 ## References
 
-[1] [P4003R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4003r3.pdf) - "A Minimal Coroutine Execution Model" (Vinnie Falco, Steve Gerbino, Mungo Gill, 2026).
+[1] [N5054](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/n5054.pdf) - "Working Draft, Programming Languages &mdash; C++" (Thomas K&ouml;ppe, 2026).
 
 [2] [P3552R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3552r3.html) - "Add a Coroutine Task Type" (Dietmar K&uuml;hl, Maikel Nadolski, 2025).
 
-[3] [P3941R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3941r2.html) - "Scheduler Affinity" (Dietmar K&uuml;hl, 2026).
+[3] [P2300R10](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html) - "`std::execution`" (Micha&#322; Dominiak, Georgy Evtushenko, Lewis Baker, Lucian Radu Teodorescu, Lee Howes, Kirk Shoop, Michael Garland, Eric Niebler, Bryce Adelstein Lelbach, 2024).
 
-[4] [P3796R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3796r1.html) - "Coroutine Task Issues" (Dietmar K&uuml;hl, 2025).
+[4] [P2257R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2257r0.html) - "Blocking is an insufficient description for senders and receivers" (Dalton M. Woodard, 2020).
 
 [5] [P3206R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3206r0.pdf) - "A sender query for completion behaviour" (Maikel Nadolski, 2025).
 
-[6] [P4088R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4088r1.pdf) - "What C++20 Coroutines Already Buy The Standard" (Vinnie Falco, 2026).
+[6] [P3570R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3570r2.html) - "optional variants in sender/receiver" (Fabio Fracassi, 2025).
 
-[7] [P4093R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4093r1.pdf) - "Producing Senders from Coroutine-Native Code" (Vinnie Falco, Steve Gerbino, 2026).
+[7] [P3796R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3796r1.html) - "Coroutine Task Issues" (Dietmar K&uuml;hl, 2025).
 
-[8] [P4092R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4092r1.pdf) - "Consuming Senders from Coroutine-Native Code" (Vinnie Falco, Steve Gerbino, 2026).
+[8] [P3941R4](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3941r4.html) - "Scheduler Affinity" (Dietmar K&uuml;hl, 2026).
 
-[9] [P4126R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4126r1.pdf) - "A Universal Continuation Model" (Vinnie Falco, Klemens Morgenstern, 2026).
+[9] [P0913R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0913r1.html) - "Add symmetric coroutine control transfer" (Gor Nishanov, 2018).
 
-[10] [N5054](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/n5054.pdf) - "Working Draft, Programming Languages &mdash; C++" (Thomas K&ouml;ppe, 2026).
+[10] [P1056R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1056r1.html) - "Add lazy coroutine (coroutine task) type" (Lewis Baker, Gor Nishanov, 2018).
 
-[11] [Capy](https://github.com/cppalliance/capy) (C++ Alliance, 2025).
+[11] [P2583R4](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p2583r4.pdf) - "Symmetric Transfer and Sender Composition" (Mungo Gill, Vinnie Falco, 2026).
 
-[12] [P2300R10](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html) - "std::execution" (Micha&lstrok; Dominiak, Georgy Evtushenko, Lewis Baker, Lucian Radu Teodorescu, Lee Howes, Kirk Shoop, Michael Garland, Eric Niebler, Bryce Adelstein Lelbach, 2024).
+[12] [P3801R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3801r0.html) - "Concerns about the design of std::execution::task" (Jonathan M&uuml;ller, 2025).
 
-[13] [NVIDIA/stdexec](https://github.com/NVIDIA/stdexec) - "A reference implementation of `std::execution`" (NVIDIA, 2021).
+[13] [P4003R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4003r3.pdf) - "A Minimal Coroutine Execution Model" (Vinnie Falco, Steve Gerbino, Mungo Gill, 2026).
 
-[14] [P3149R11](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3149r11.html) - "async_scope &ndash; Creating scopes for non-sequential concurrency" (Ian Petersen, Jessica Wong, 2025).
+[14] [P4092R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4092r1.pdf) - "Consuming Senders from Coroutine-Native Code" (Vinnie Falco, Steve Gerbino, 2026).
 
-[15] [Corosio](https://github.com/cppalliance/corosio) (C++ Alliance, 2026).
+[15] [P4093R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4093r1.pdf) - "Producing Senders from Coroutine-Native Code" (Vinnie Falco, Steve Gerbino, 2026).
 
-[16] [P0159R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0159r0.html) - "Draft of Technical Specification for C++ Extensions for Concurrency" (Artur Laksberg, 2015).
+[16] [P4126R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4126r1.pdf) - "A Universal Continuation Model" (Vinnie Falco, Klemens Morgenstern, 2026).
 
-[17] [P2583R4](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p2583r4.pdf) - "Symmetric Transfer and Sender Composition" (Mungo Gill, Vinnie Falco, 2026).
+[17] [P3149R11](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3149r11.html) - "`async_scope` &ndash; Creating scopes for non-sequential concurrency" (Ian Petersen, Jessica Wong, 2025).
+
+[18] [WSARecv](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsarecv) - "WSARecv function (winsock2.h)" (Microsoft, 2018).
+
+[19] [SetFileCompletionNotificationModes](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setfilecompletionnotificationmodes) - "SetFileCompletionNotificationModes function (winbase.h)" (Microsoft, 2018).
+
+[20] [WSAEventSelect](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsaeventselect) - "WSAEventSelect function (winsock2.h)" (Microsoft, 2018).
+
+[21] [NVIDIA/stdexec](https://github.com/NVIDIA/stdexec/tree/2c56ffe7f8a2b8b5221918159092be379ae8b40f) - "`std::execution` reference implementation" (NVIDIA, 2026).
+
+[22] [Capy](https://github.com/cppalliance/capy) - "C++20 coroutine I/O foundation and sender benchmarks" (C++ Alliance, 2026).
+
+[23] [Beman.Execution](https://github.com/bemanproject/execution/tree/a20a6f636be4e8d0588521670a178f342695ece8) - "`std::execution` implementation" (Beman Project, 2026).
+
+[24] [Corosio](https://github.com/cppalliance/corosio) - "Coroutine-native networking library" (C++ Alliance, 2026).


### PR DESCRIPTION
Replace P4253's six-observation argument with a `let_value` ownership-lifetime analysis backed by matched signatures and I/O contracts. Rebuild P4255 around coroutine-centric I/O leaf readiness, the complete `as_awaitable` branch structure, and scoped implementation evidence. Both papers now state counterexamples, safe alternatives, and limitations without treating protocol structure as measured runtime cost.